### PR TITLE
Fix build compatibility with GCC 15

### DIFF
--- a/src/modules/signal_generator/benchmark.cc
+++ b/src/modules/signal_generator/benchmark.cc
@@ -35,10 +35,10 @@ void benchmark(ankerl::nanobench::Bench& bench, std::string name) {
     JST_BENCHMARK_RUN("Chirp 8192", {
         .signalType = SignalType::Chirp COMMA
         .sampleRate = 1000000.0 COMMA
+        .amplitude = 1.0 COMMA
         .chirpStartFreq = 1000.0 COMMA
         .chirpEndFreq = 10000.0 COMMA
         .chirpDuration = 1.0 COMMA
-        .amplitude = 1.0 COMMA
         .bufferSize = 8192
     }, {}, IT);
 

--- a/tests/components/common.hh
+++ b/tests/components/common.hh
@@ -9,7 +9,12 @@
 using namespace Jetstream;
 
 constexpr static Device ComputeDevice = Device::CPU;
+#ifdef JETSTREAM_BACKEND_VULKAN_AVAILABLE
+constexpr static Device RenderDevice  = Device::Vulkan;
+#endif
+#ifdef JETSTREAM_BACKEND_METAL_AVAILABLE
 constexpr static Device RenderDevice  = Device::Metal;
+#endif
 using ViewportPlatform = Viewport::GLFW<RenderDevice>;
 
 class MagnifierGlass {


### PR DESCRIPTION
## Summary

This PR fixes two build issues encountered when compiling CyberEther on Arch Linux with modern GCC (15.x).

### Changes

1. **Fix designated initializer order in `signal_generator` benchmark** (`src/modules/signal_generator/benchmark.cc`)
   - C++20 designated initializers must be specified in the same order as the struct field declarations
   - The `amplitude` field was incorrectly placed after `chirpDuration` in the "Chirp 8192" benchmark
   - Moved `amplitude` before `chirpStartFreq` to match the `Config` struct declaration order

2. **Fix test components to use correct render backend per platform** (`tests/components/common.hh`)
   - Hardcoded `Device::Metal` caused compilation failures on Linux where Metal is unavailable
   - Added conditional compilation to select `Device::Vulkan` on Linux and `Device::Metal` on macOS

### Error Messages Fixed

**Before (designator order error):**
```
error: designator order for field 'Jetstream::SignalGenerator<...>::Config::amplitude' does not match declaration order
```

**Before (shared_ptr inheritance error on Linux):**
```
error: no match for 'operator=' (operand types are 'std::shared_ptr<Jetstream::Viewport::Generic>' and 'std::shared_ptr<Jetstream::Viewport::GLFW<Jetstream::Device::Metal>>')
```

## Testing

- Successfully compiled on Arch Linux with GCC 15.2.1
- Build completed with `meson setup -Dbuildtype=debugoptimized build && cd build && ninja install`