### PR TITLE
refactor: thread-safe getters for module and block communication

### DIFF
--- a/include/jetstream/tools/snapshot.hh
+++ b/include/jetstream/tools/snapshot.hh
@@ -1,0 +1,76 @@
+#ifndef JETSTREAM_TOOLS_SNAPSHOT_HH
+#define JETSTREAM_TOOLS_SNAPSHOT_HH
+
+#include <atomic>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+namespace Jetstream::Tools {
+
+template<typename T, typename Enable = void>
+class Snapshot;
+
+template<typename T>
+class Snapshot<T, std::enable_if_t<std::is_trivially_copyable_v<T>>> {
+ public:
+    Snapshot() : value(T{}) {}
+    Snapshot(const T& initial) : value(initial) {}
+    Snapshot(T&& initial) : value(std::move(initial)) {}
+
+    Snapshot(const Snapshot&) = delete;
+    Snapshot& operator=(const Snapshot&) = delete;
+    Snapshot(Snapshot&&) = delete;
+    Snapshot& operator=(Snapshot&&) = delete;
+
+    void publish(const T& newValue) {
+        value.store(newValue, std::memory_order_release);
+    }
+
+    void publish(T&& newValue) {
+        value.store(std::move(newValue), std::memory_order_release);
+    }
+
+    T get() const {
+        return value.load(std::memory_order_acquire);
+    }
+
+ private:
+    std::atomic<T> value;
+};
+
+template<typename T>
+class Snapshot<T, std::enable_if_t<!std::is_trivially_copyable_v<T>>> {
+ public:
+    Snapshot() : value(std::make_shared<const T>()) {}
+    Snapshot(const T& initial) : value(std::make_shared<const T>(initial)) {}
+    Snapshot(T&& initial) : value(std::make_shared<const T>(std::move(initial))) {}
+
+    Snapshot(const Snapshot&) = delete;
+    Snapshot& operator=(const Snapshot&) = delete;
+    Snapshot(Snapshot&&) = delete;
+    Snapshot& operator=(Snapshot&&) = delete;
+
+    void publish(const T& newValue) {
+        std::atomic_store_explicit(&value,
+                                   std::make_shared<const T>(newValue),
+                                   std::memory_order_release);
+    }
+
+    void publish(T&& newValue) {
+        std::atomic_store_explicit(&value,
+                                   std::make_shared<const T>(std::move(newValue)),
+                                   std::memory_order_release);
+    }
+
+    T get() const {
+        return *std::atomic_load_explicit(&value, std::memory_order_acquire);
+    }
+
+ private:
+    std::shared_ptr<const T> value;
+};
+
+}  // namespace Jetstream::Tools
+
+#endif  // JETSTREAM_TOOLS_SNAPSHOT_HH

--- a/src/domains/dsp/adsb/module_impl.cc
+++ b/src/domains/dsp/adsb/module_impl.cc
@@ -45,6 +45,7 @@ Result AdsbImpl::create() {
     {
         std::lock_guard<std::mutex> lock(aircraftMutex);
         aircraftMap.clear();
+        aircraftTableDirty = true;
         hoveredFlightId.clear();
         hoveredFlightNdc = {0.0f, 0.0f};
         hasLastCursorSample = false;
@@ -59,57 +60,69 @@ Result AdsbImpl::create() {
     return Result::SUCCESS;
 }
 
-std::string AdsbImpl::getAircraftTable() {
-    std::lock_guard<std::mutex> lock(aircraftMutex);
-
-    if (aircraftMap.empty()) {
-        return "No aircraft detected.";
-    }
-
-    std::string table;
-    table += "ICAO\tCallsign\tAlt (ft)\tSpeed (kt)\tHdg\tLat\tLon\n";
-
-    for (const auto& [icao, ac] : aircraftMap) {
-        table += jst::fmt::format("{:06X}\t{}\t{}\t{}\t{}\t{}\t{}\n",
-            icao,
-            ac.hasCallsign ? ac.callsign : "-",
-            ac.hasAltitude ? jst::fmt::format("{}", ac.altitude) : "-",
-            ac.hasVelocity ? jst::fmt::format("{:.0f}", ac.speed) : "-",
-            ac.hasVelocity ? jst::fmt::format("{:.0f}", ac.heading) : "-",
-            ac.hasPosition ? jst::fmt::format("{:.4f}", ac.latitude) : "-",
-            ac.hasPosition ? jst::fmt::format("{:.4f}", ac.longitude) : "-");
-    }
-
-    return table;
+std::string AdsbImpl::getAircraftTable() const {
+    return aircraftTable.get();
 }
 
 void AdsbImpl::updateOutputTensors() {
-    std::lock_guard<std::mutex> lock(aircraftMutex);
+    std::string nextAircraftTable;
+    bool publishAircraftTable = false;
 
-    F32* data = static_cast<F32*>(aircraft.data());
-    U64* count = static_cast<U64*>(aircraftCount.data());
+    {
+        std::lock_guard<std::mutex> lock(aircraftMutex);
 
-    U64 idx = 0;
-    for (const auto& [icao, ac] : aircraftMap) {
-        if (!ac.hasPosition || idx >= maxAircraft) {
-            continue;
+        F32* data = static_cast<F32*>(aircraft.data());
+        U64* count = static_cast<U64*>(aircraftCount.data());
+
+        U64 idx = 0;
+        for (const auto& [icao, ac] : aircraftMap) {
+            if (!ac.hasPosition || idx >= maxAircraft) {
+                continue;
+            }
+            data[idx * 4 + 0] = static_cast<F32>(ac.latitude);
+            data[idx * 4 + 1] = static_cast<F32>(ac.longitude);
+            data[idx * 4 + 2] = ac.heading;
+            data[idx * 4 + 3] = static_cast<F32>(ac.altitude);
+            idx++;
         }
-        data[idx * 4 + 0] = static_cast<F32>(ac.latitude);
-        data[idx * 4 + 1] = static_cast<F32>(ac.longitude);
-        data[idx * 4 + 2] = ac.heading;
-        data[idx * 4 + 3] = static_cast<F32>(ac.altitude);
-        idx++;
+
+        // Zero remaining entries.
+        for (U64 i = idx; i < maxAircraft; ++i) {
+            data[i * 4 + 0] = 0.0f;
+            data[i * 4 + 1] = 0.0f;
+            data[i * 4 + 2] = 0.0f;
+            data[i * 4 + 3] = 0.0f;
+        }
+
+        count[0] = idx;
+
+        if (aircraftTableDirty) {
+            publishAircraftTable = true;
+
+            if (aircraftMap.empty()) {
+                nextAircraftTable = "No aircraft detected.";
+            } else {
+                nextAircraftTable += "ICAO\tCallsign\tAlt (ft)\tSpeed (kt)\tHdg\tLat\tLon\n";
+
+                for (const auto& [icao, ac] : aircraftMap) {
+                    nextAircraftTable += jst::fmt::format("{:06X}\t{}\t{}\t{}\t{}\t{}\t{}\n",
+                        icao,
+                        ac.hasCallsign ? ac.callsign : "-",
+                        ac.hasAltitude ? jst::fmt::format("{}", ac.altitude) : "-",
+                        ac.hasVelocity ? jst::fmt::format("{:.0f}", ac.speed) : "-",
+                        ac.hasVelocity ? jst::fmt::format("{:.0f}", ac.heading) : "-",
+                        ac.hasPosition ? jst::fmt::format("{:.4f}", ac.latitude) : "-",
+                        ac.hasPosition ? jst::fmt::format("{:.4f}", ac.longitude) : "-");
+                }
+            }
+
+            aircraftTableDirty = false;
+        }
     }
 
-    // Zero remaining entries.
-    for (U64 i = idx; i < maxAircraft; ++i) {
-        data[i * 4 + 0] = 0.0f;
-        data[i * 4 + 1] = 0.0f;
-        data[i * 4 + 2] = 0.0f;
-        data[i * 4 + 3] = 0.0f;
+    if (publishAircraftTable) {
+        aircraftTable.publish(std::move(nextAircraftTable));
     }
-
-    count[0] = idx;
 }
 
 // Rendering lifecycle.

--- a/src/domains/dsp/adsb/module_impl.hh
+++ b/src/domains/dsp/adsb/module_impl.hh
@@ -11,6 +11,7 @@
 #include <jetstream/domains/dsp/adsb/module.hh>
 #include <jetstream/detail/module_impl.hh>
 #include <jetstream/surface.hh>
+#include <jetstream/tools/snapshot.hh>
 #include <jetstream/render/base/buffer.hh>
 #include <jetstream/render/base/texture.hh>
 #include <jetstream/render/base/surface.hh>
@@ -53,7 +54,7 @@ struct AdsbImpl : public Module::Impl, public DynamicConfig<Adsb> {
         U64 oddTimestamp = 0;
     };
 
-    std::string getAircraftTable();
+    std::string getAircraftTable() const;
     void updateOutputTensors();
 
  protected:
@@ -63,9 +64,11 @@ struct AdsbImpl : public Module::Impl, public DynamicConfig<Adsb> {
     Tensor input;
     Tensor aircraft;
     Tensor aircraftCount;
+    Tools::Snapshot<std::string> aircraftTable{std::string("No aircraft detected.")};
 
-    std::mutex aircraftMutex;
+    mutable std::mutex aircraftMutex;
     std::map<U32, AircraftInfo> aircraftMap;
+    bool aircraftTableDirty = true;
     std::string hoveredFlightId;
     Extent2D<F32> hoveredFlightNdc = {0.0f, 0.0f};
     bool hasLastCursorSample = false;

--- a/src/domains/dsp/adsb/module_impl_native_cpu.cc
+++ b/src/domains/dsp/adsb/module_impl_native_cpu.cc
@@ -216,6 +216,8 @@ void AdsbImplNativeCpu::updateAircraftFromMessage(const struct mode_s_msg* mm) {
             }
         }
     }
+
+    aircraftTableDirty = true;
 }
 
 Result AdsbImplNativeCpu::create() {
@@ -255,7 +257,6 @@ Result AdsbImplNativeCpu::computeSubmit() {
     const CF32* iqData = reinterpret_cast<const CF32*>(input.data());
     const U64 numSamples = input.size();
 
-    // Convert CF32 IQ to U16 magnitude in libmodes scale.
     for (U64 i = 0; i < numSamples; ++i) {
         const F32 real = iqData[i].real() * 128.0f;
         const F32 imag = iqData[i].imag() * 128.0f;
@@ -270,7 +271,6 @@ Result AdsbImplNativeCpu::computeSubmit() {
                   &AdsbImplNativeCpu::messageCallback);
     tls_instance = nullptr;
 
-    // Update output tensors with current aircraft positions.
     updateOutputTensors();
 
     return Result::SUCCESS;

--- a/src/domains/dsp/squelch/block_impl.cc
+++ b/src/domains/dsp/squelch/block_impl.cc
@@ -35,7 +35,7 @@ Result SquelchImpl::define() {
                 return std::string("Closed");
             }
 
-            return std::string(moduleImpl->passing() ? "Open" : "Closed");
+            return std::string(moduleImpl->getPassing() ? "Open" : "Closed");
         }));
 
     JST_CHECK(defineInterfaceMetric("amplitude",
@@ -47,7 +47,7 @@ Result SquelchImpl::define() {
                 return std::string("0.000");
             }
 
-            return jst::fmt::format("{:.3f}", moduleImpl->amplitude());
+            return jst::fmt::format("{:.3f}", moduleImpl->getAmplitude());
         }));
 
     JST_CHECK(defineInterfaceConfig("threshold",

--- a/src/domains/dsp/squelch/module_impl.cc
+++ b/src/domains/dsp/squelch/module_impl.cc
@@ -29,15 +29,15 @@ Result SquelchImpl::create() {
     output = input.clone();
     outputs()["signal"].produced(name(), "signal", output);
 
-    passingState.store(false, std::memory_order_relaxed);
-    amplitudeState.store(0.0f, std::memory_order_relaxed);
+    passingState.publish(false);
+    amplitudeState.publish(0.0f);
 
     return Result::SUCCESS;
 }
 
 Result SquelchImpl::destroy() {
-    passingState.store(false, std::memory_order_relaxed);
-    amplitudeState.store(0.0f, std::memory_order_relaxed);
+    passingState.publish(false);
+    amplitudeState.publish(0.0f);
     return Result::SUCCESS;
 }
 
@@ -54,11 +54,11 @@ Result SquelchImpl::reconfigure() {
 }
 
 bool SquelchImpl::getPassing() const {
-    return passingState.load(std::memory_order_relaxed);
+    return passingState.get();
 }
 
 F32 SquelchImpl::getAmplitude() const {
-    return amplitudeState.load(std::memory_order_relaxed);
+    return amplitudeState.get();
 }
 
 }  // namespace Jetstream::Modules

--- a/src/domains/dsp/squelch/module_impl.cc
+++ b/src/domains/dsp/squelch/module_impl.cc
@@ -53,4 +53,12 @@ Result SquelchImpl::reconfigure() {
     return Result::SUCCESS;
 }
 
+bool SquelchImpl::getPassing() const {
+    return passingState.load(std::memory_order_relaxed);
+}
+
+F32 SquelchImpl::getAmplitude() const {
+    return amplitudeState.load(std::memory_order_relaxed);
+}
+
 }  // namespace Jetstream::Modules

--- a/src/domains/dsp/squelch/module_impl.hh
+++ b/src/domains/dsp/squelch/module_impl.hh
@@ -1,10 +1,9 @@
 #ifndef JETSTREAM_DOMAINS_DSP_SQUELCH_MODULE_IMPL_HH
 #define JETSTREAM_DOMAINS_DSP_SQUELCH_MODULE_IMPL_HH
 
-#include <atomic>
-
 #include <jetstream/domains/dsp/squelch/module.hh>
 #include <jetstream/detail/module_impl.hh>
+#include <jetstream/tools/snapshot.hh>
 
 namespace Jetstream::Modules {
 
@@ -22,8 +21,8 @@ struct SquelchImpl : public Module::Impl, public DynamicConfig<Squelch> {
   protected:
     Tensor input;
     Tensor output;
-    std::atomic<bool> passingState{false};
-    std::atomic<F32> amplitudeState{0.0f};
+    Tools::Snapshot<bool> passingState{false};
+    Tools::Snapshot<F32> amplitudeState{0.0f};
 };
 
 }  // namespace Jetstream::Modules

--- a/src/domains/dsp/squelch/module_impl.hh
+++ b/src/domains/dsp/squelch/module_impl.hh
@@ -16,13 +16,8 @@ struct SquelchImpl : public Module::Impl, public DynamicConfig<Squelch> {
     Result destroy() override;
     Result reconfigure() override;
 
-    bool passing() const {
-        return passingState.load(std::memory_order_relaxed);
-    }
-
-    F32 amplitude() const {
-        return amplitudeState.load(std::memory_order_relaxed);
-    }
+    bool getPassing() const;
+    F32 getAmplitude() const;
 
   protected:
     Tensor input;

--- a/src/domains/dsp/squelch/module_impl_native_cpu.cc
+++ b/src/domains/dsp/squelch/module_impl_native_cpu.cc
@@ -56,8 +56,8 @@ Result SquelchImplNativeCpu::kernelCF32() {
     }
 
     const bool shouldPass = peakAmplitude > threshold;
-    passingState.store(shouldPass, std::memory_order_relaxed);
-    amplitudeState.store(peakAmplitude, std::memory_order_relaxed);
+    passingState.publish(shouldPass);
+    amplitudeState.publish(peakAmplitude);
     return shouldPass ? Result::SUCCESS : Result::SKIP;
 }
 
@@ -71,8 +71,8 @@ Result SquelchImplNativeCpu::kernelF32() {
     }
 
     const bool shouldPass = peakAmplitude > threshold;
-    passingState.store(shouldPass, std::memory_order_relaxed);
-    amplitudeState.store(peakAmplitude, std::memory_order_relaxed);
+    passingState.publish(shouldPass);
+    amplitudeState.publish(peakAmplitude);
     return shouldPass ? Result::SUCCESS : Result::SKIP;
 }
 

--- a/src/domains/io/file_reader/block_impl.cc
+++ b/src/domains/io/file_reader/block_impl.cc
@@ -70,7 +70,7 @@ Result FileReaderImpl::define() {
             if (!moduleImpl) {
                 return std::pair<std::string, F32>{"0.0%", 0.0f};
             }
-            const U64& size = moduleImpl->getFileSize();
+            const U64 size = moduleImpl->getFileSize();
             if (size == 0) {
                 return std::pair<std::string, F32>{"0.0%", 0.0f};
             }

--- a/src/domains/io/file_reader/module_impl.cc
+++ b/src/domains/io/file_reader/module_impl.cc
@@ -44,6 +44,8 @@ Result FileReaderImpl::create() {
     JST_CHECK(buffer.create(device(), NameToDataType(dataType), {batchSize}));
 
     outputs()["signal"].produced(name(), "signal", buffer);
+    fileSize.publish(0);
+    currentPosition.publish(0);
 
     if (filepath.empty()) {
         JST_WARN("[MODULE_FILE_READER] File path is empty.");
@@ -58,11 +60,12 @@ Result FileReaderImpl::create() {
     }
 
     std::error_code ec;
-    fileSize = std::filesystem::file_size(filePath, ec);
+    const U64 inputFileSize = std::filesystem::file_size(filePath, ec);
     if (ec) {
         JST_WARN("[MODULE_FILE_READER] Failed to get file size for '{}'.", filePath.string());
         return Result::INCOMPLETE;
     }
+    fileSize.publish(inputFileSize);
 
     dataFile.open(filePath, std::ios::in | std::ios::binary);
     if (!dataFile.is_open()) {
@@ -70,9 +73,7 @@ Result FileReaderImpl::create() {
         return Result::INCOMPLETE;
     }
 
-    currentPosition = 0;
-
-    JST_INFO("[MODULE_FILE_READER] Opened '{}' ({} bytes).", filePath.string(), fileSize);
+    JST_INFO("[MODULE_FILE_READER] Opened '{}' ({} bytes).", filePath.string(), fileSize.get());
 
     return Result::SUCCESS;
 }
@@ -100,12 +101,12 @@ Result FileReaderImpl::reconfigure() {
     return Result::RECREATE;
 }
 
-const U64& FileReaderImpl::getCurrentPosition() const {
-    return currentPosition;
+U64 FileReaderImpl::getCurrentPosition() const {
+    return currentPosition.get();
 }
 
-const U64& FileReaderImpl::getFileSize() const {
-    return fileSize;
+U64 FileReaderImpl::getFileSize() const {
+    return fileSize.get();
 }
 
 }  // namespace Jetstream::Modules

--- a/src/domains/io/file_reader/module_impl.hh
+++ b/src/domains/io/file_reader/module_impl.hh
@@ -6,6 +6,7 @@
 
 #include <jetstream/domains/io/file_reader/module.hh>
 #include <jetstream/detail/module_impl.hh>
+#include <jetstream/tools/snapshot.hh>
 
 namespace Jetstream::Modules {
 
@@ -17,16 +18,16 @@ struct FileReaderImpl : public Module::Impl, public DynamicConfig<FileReader> {
     Result destroy() override;
     Result reconfigure() override;
 
-    const U64& getCurrentPosition() const;
-    const U64& getFileSize() const;
+    U64 getCurrentPosition() const;
+    U64 getFileSize() const;
 
  protected:
     Tensor buffer;
 
     std::ifstream dataFile;
     std::filesystem::path filePath;
-    U64 fileSize = 0;
-    U64 currentPosition = 0;
+    Tools::Snapshot<U64> fileSize{0};
+    Tools::Snapshot<U64> currentPosition{0};
 };
 
 }  // namespace Jetstream::Modules

--- a/src/domains/io/file_reader/module_impl_native_cpu.cc
+++ b/src/domains/io/file_reader/module_impl_native_cpu.cc
@@ -30,12 +30,16 @@ Result FileReaderImplNativeCpu::computeSubmit() {
     }
 
     const U64 bytesToRead = buffer.sizeBytes();
-    const U64 remainingBytes = fileSize - currentPosition;
+    const U64 totalSize = fileSize.get();
+    U64 currentOffset = currentPosition.get();
+    U64 remainingBytes = totalSize - currentOffset;
 
     if (remainingBytes == 0) {
         if (loop) {
             dataFile.seekg(0, std::ios::beg);
-            currentPosition = 0;
+            currentOffset = 0;
+            currentPosition.publish(currentOffset);
+            remainingBytes = totalSize;
         } else {
             return Result::SUCCESS;
         }
@@ -44,7 +48,8 @@ Result FileReaderImplNativeCpu::computeSubmit() {
     const U64 actualBytesToRead = std::min(bytesToRead, remainingBytes);
 
     dataFile.read(reinterpret_cast<char*>(buffer.data()), actualBytesToRead);
-    currentPosition += dataFile.gcount();
+    currentOffset += dataFile.gcount();
+    currentPosition.publish(currentOffset);
 
     return Result::SUCCESS;
 }

--- a/src/domains/io/file_writer/module_impl.cc
+++ b/src/domains/io/file_writer/module_impl.cc
@@ -21,7 +21,7 @@ Result FileWriterImpl::define() {
 }
 
 Result FileWriterImpl::create() {
-    bytesWritten = 0;
+    bytesWritten.publish(0);
     filePath.clear();
 
     if (!filepath.empty()) {
@@ -29,9 +29,9 @@ Result FileWriterImpl::create() {
 
         std::error_code ec;
         if (std::filesystem::exists(filePath, ec) && !ec) {
-            bytesWritten = std::filesystem::file_size(filePath, ec);
+            bytesWritten.publish(std::filesystem::file_size(filePath, ec));
             if (ec) {
-                bytesWritten = 0;
+                bytesWritten.publish(0);
             }
         }
     }
@@ -64,7 +64,7 @@ Result FileWriterImpl::create() {
         return Result::ERROR;
     }
 
-    bytesWritten = 0;
+    bytesWritten.publish(0);
 
     JST_INFO("[MODULE_FILE_WRITER] Opened '{}' for writing.", filePath.string());
 
@@ -76,14 +76,14 @@ Result FileWriterImpl::destroy() {
         dataFile.close();
         JST_INFO("[MODULE_FILE_WRITER] Closed '{}' ({} bytes written).",
                  filePath.string(),
-                 bytesWritten);
+                 bytesWritten.get());
     }
 
     return Result::SUCCESS;
 }
 
 U64 FileWriterImpl::getBytesWritten() const {
-    return bytesWritten;
+    return bytesWritten.get();
 }
 
 }  // namespace Jetstream::Modules

--- a/src/domains/io/file_writer/module_impl.hh
+++ b/src/domains/io/file_writer/module_impl.hh
@@ -6,6 +6,7 @@
 
 #include <jetstream/domains/io/file_writer/module.hh>
 #include <jetstream/detail/module_impl.hh>
+#include <jetstream/tools/snapshot.hh>
 
 namespace Jetstream::Modules {
 
@@ -21,7 +22,7 @@ struct FileWriterImpl : public Module::Impl, public DynamicConfig<FileWriter> {
  protected:
     std::ofstream dataFile;
     std::filesystem::path filePath;
-    U64 bytesWritten = 0;
+    Tools::Snapshot<U64> bytesWritten{0};
 };
 
 }  // namespace Jetstream::Modules

--- a/src/domains/io/file_writer/module_impl_native_cpu.cc
+++ b/src/domains/io/file_writer/module_impl_native_cpu.cc
@@ -58,7 +58,7 @@ Result FileWriterImplNativeCpu::computeSubmit() {
         return Result::ERROR;
     }
 
-    bytesWritten += bytesToWrite;
+    bytesWritten.publish(bytesWritten.get() + bytesToWrite);
 
     return Result::SUCCESS;
 }

--- a/src/domains/io/soapy/block_impl.cc
+++ b/src/domains/io/soapy/block_impl.cc
@@ -135,7 +135,7 @@ Result SoapyImpl::define() {
             if (!moduleImpl) {
                 return std::string("N/A");
             }
-            const auto& [actual, expected] = moduleImpl->getThroughput();
+            const auto [actual, expected] = moduleImpl->getThroughput();
             return jst::fmt::format("{:.1f} / {:.1f} MB/s", actual, expected);
         }));
 

--- a/src/domains/io/soapy/module_impl.cc
+++ b/src/domains/io/soapy/module_impl.cc
@@ -44,8 +44,8 @@ Result SoapyImpl::create() {
 
     errored = false;
     streaming = false;
-    deviceName = "None";
-    deviceHardwareKey = "None";
+    bufferHealth.publish(0.0f);
+    throughput.publish({0.0f, 0.0f});
 
     SoapySDR::Kwargs args = SoapySDR::KwargsFromString(deviceString);
     SoapySDR::Kwargs streamArgs = SoapySDR::KwargsFromString(streamString);
@@ -67,7 +67,6 @@ Result SoapyImpl::create() {
             JST_ERROR("[MODULE_SOAPY] No SoapySDR devices found.");
             return Result::INCOMPLETE;
         }
-        deviceLabel = devices.at(0).at("label");
         soapyDevice = SoapySDR::Device::make(devices.at(0));
     } catch (const std::exception& e) {
         JST_ERROR("[MODULE_SOAPY] Failed to open device: {}", e.what());
@@ -125,8 +124,6 @@ Result SoapyImpl::create() {
         }
         soapyDevice->activateStream(soapyStream, 0, 0, 0);
 
-        deviceName = soapyDevice->getDriverKey();
-        deviceHardwareKey = soapyDevice->getHardwareKey();
     } catch (const std::exception& e) {
         JST_ERROR("[MODULE_SOAPY] Failed to configure device: {}", e.what());
         if (soapyStream) {
@@ -198,6 +195,9 @@ Result SoapyImpl::destroy() {
         soapyDevice = nullptr;
     }
 
+    bufferHealth.publish(0.0f);
+    throughput.publish({0.0f, 0.0f});
+
     return Result::SUCCESS;
 }
 
@@ -243,11 +243,12 @@ Result SoapyImpl::soapyThreadLoop() {
                 if (capacity > 0) {
                     const F32 newHealth = static_cast<F32>(circularBuffer.getOccupancy()) /
                                           static_cast<F32>(capacity);
-                    bufferHealth = bufferHealth * 0.99f + newHealth * 0.01f;
+                    const F32 smoothedHealth = bufferHealth.get() * 0.99f + newHealth * 0.01f;
+                    bufferHealth.publish(smoothedHealth);
                 }
                 const F32 actualMB = static_cast<F32>(circularBuffer.getThroughput() * sizeof(CF32)) / 1e6f;
                 const F32 expectedMB = (sampleRate * sizeof(CF32)) / 1e6f;
-                throughput = {actualMB, expectedMB};
+                throughput.publish({actualMB, expectedMB});
             }
         } catch (const std::exception& e) {
             JST_ERROR("[MODULE_SOAPY] Failed to read stream: {}", e.what());
@@ -300,28 +301,12 @@ bool SoapyImpl::CheckValidRange(const std::vector<SoapySDR::Range>& ranges, cons
     return false;
 }
 
-Tools::CircularBuffer<CF32>& SoapyImpl::getCircularBuffer() {
-    return circularBuffer;
+F32 SoapyImpl::getBufferHealth() const {
+    return bufferHealth.get();
 }
 
-const std::string& SoapyImpl::getDeviceName() const {
-    return deviceName;
-}
-
-const std::string& SoapyImpl::getDeviceHardwareKey() const {
-    return deviceHardwareKey;
-}
-
-const std::string& SoapyImpl::getDeviceLabel() const {
-    return deviceLabel;
-}
-
-const F32& SoapyImpl::getBufferHealth() const {
-    return bufferHealth;
-}
-
-const std::pair<F32, F32>& SoapyImpl::getThroughput() const {
-    return throughput;
+std::pair<F32, F32> SoapyImpl::getThroughput() const {
+    return throughput.get();
 }
 
 Result SoapyImpl::setTunerFrequency(const F32& freq) {

--- a/src/domains/io/soapy/module_impl.hh
+++ b/src/domains/io/soapy/module_impl.hh
@@ -12,6 +12,7 @@
 #include <jetstream/domains/io/soapy/module.hh>
 #include <jetstream/detail/module_impl.hh>
 #include <jetstream/tools/circular_buffer.hh>
+#include <jetstream/tools/snapshot.hh>
 
 namespace Jetstream::Modules {
 
@@ -29,12 +30,8 @@ struct SoapyImpl : public Module::Impl, public DynamicConfig<Soapy> {
     static DeviceList ListAvailableDevices(const std::string& filter = "");
     static std::string DeviceEntryToString(const DeviceEntry& entry);
 
-    Tools::CircularBuffer<CF32>& getCircularBuffer();
-    const std::string& getDeviceName() const;
-    const std::string& getDeviceHardwareKey() const;
-    const std::string& getDeviceLabel() const;
-    const F32& getBufferHealth() const;
-    const std::pair<F32, F32>& getThroughput() const;
+    F32 getBufferHealth() const;
+    std::pair<F32, F32> getThroughput() const;
 
     Result setTunerFrequency(const F32& frequency);
     Result setSampleRate(const F32& sampleRate);
@@ -53,13 +50,9 @@ struct SoapyImpl : public Module::Impl, public DynamicConfig<Soapy> {
     std::atomic<bool> errored{false};
     std::atomic<bool> streaming{false};
 
-    std::string deviceLabel;
-    std::string deviceName;
-    std::string deviceHardwareKey;
-
     Tools::CircularBuffer<CF32> circularBuffer;
-    F32 bufferHealth = 0.0f;
-    std::pair<F32, F32> throughput = {0.0f, 0.0f};
+    Tools::Snapshot<F32> bufferHealth{0.0f};
+    Tools::Snapshot<std::pair<F32, F32>> throughput{{0.0f, 0.0f}};
 
     Result soapyThreadLoop();
     static bool CheckValidRange(const std::vector<SoapySDR::Range>& ranges, const F32& val);

--- a/src/domains/io/websocket/module_impl.cc
+++ b/src/domains/io/websocket/module_impl.cc
@@ -53,6 +53,8 @@ Result WebsocketImpl::create() {
 
     errored = false;
     connected = false;
+    bufferHealth.publish(0.0f);
+    throughputMBs.publish(0.0f);
 
     JST_CHECK(buffer.create(device(), NameToDataType(dataType),
                             {numberOfBatches, numberOfTimeSamples}));
@@ -91,6 +93,8 @@ Result WebsocketImpl::destroy() {
     }
 
     connected = false;
+    bufferHealth.publish(0.0f);
+    throughputMBs.publish(0.0f);
 
     return Result::SUCCESS;
 }
@@ -121,10 +125,11 @@ EM_BOOL WebsocketImpl::onMessage(int,
     if (capacity > 0) {
         const F32 newHealth = static_cast<F32>(self->circularBuffer.getOccupancy()) /
                               static_cast<F32>(capacity);
-        self->bufferHealth = self->bufferHealth * 0.99f + newHealth * 0.01f;
+        const F32 smoothedHealth = self->bufferHealth.get() * 0.99f + newHealth * 0.01f;
+        self->bufferHealth.publish(smoothedHealth);
     }
 
-    self->throughputMBs = static_cast<F32>(self->circularBuffer.getThroughput()) / 1e6f;
+    self->throughputMBs.publish(static_cast<F32>(self->circularBuffer.getThroughput()) / 1e6f);
 
     return EM_TRUE;
 }
@@ -148,16 +153,12 @@ EM_BOOL WebsocketImpl::onError(int,
     return EM_TRUE;
 }
 
-Tools::CircularBuffer<I8>& WebsocketImpl::getCircularBuffer() {
-    return circularBuffer;
+F32 WebsocketImpl::getBufferHealth() const {
+    return bufferHealth.get();
 }
 
-const F32& WebsocketImpl::getBufferHealth() const {
-    return bufferHealth;
-}
-
-const F32& WebsocketImpl::getThroughput() const {
-    return throughputMBs;
+F32 WebsocketImpl::getThroughput() const {
+    return throughputMBs.get();
 }
 
 }  // namespace Jetstream::Modules

--- a/src/domains/io/websocket/module_impl.hh
+++ b/src/domains/io/websocket/module_impl.hh
@@ -8,6 +8,7 @@
 #include <jetstream/domains/io/websocket/module.hh>
 #include <jetstream/detail/module_impl.hh>
 #include <jetstream/tools/circular_buffer.hh>
+#include <jetstream/tools/snapshot.hh>
 
 namespace Jetstream::Modules {
 
@@ -18,9 +19,8 @@ struct WebsocketImpl : public Module::Impl, public DynamicConfig<Websocket> {
     Result create() override;
     Result destroy() override;
 
-    Tools::CircularBuffer<I8>& getCircularBuffer();
-    const F32& getBufferHealth() const;
-    const F32& getThroughput() const;
+    F32 getBufferHealth() const;
+    F32 getThroughput() const;
 
  protected:
     Tensor buffer;
@@ -30,8 +30,8 @@ struct WebsocketImpl : public Module::Impl, public DynamicConfig<Websocket> {
     std::atomic<bool> errored{false};
 
     Tools::CircularBuffer<I8> circularBuffer;
-    F32 bufferHealth = 0.0f;
-    F32 throughputMBs = 0.0f;
+    Tools::Snapshot<F32> bufferHealth{0.0f};
+    Tools::Snapshot<F32> throughputMBs{0.0f};
 
     static EM_BOOL onOpen(int eventType,
                           const EmscriptenWebSocketOpenEvent* event,

--- a/tests/memory/meson.build
+++ b/tests/memory/meson.build
@@ -3,6 +3,11 @@ test('memory-token', executable(
     dependencies: [libjetstream_dep, catch2_dep],
 ), is_parallel: false, timeout: 0)
 
+test('memory-snapshot', executable(
+    'jetstream-memory-snapshot', 'snapshot.cc',
+    dependencies: [libjetstream_dep, catch2_dep],
+), is_parallel: false, timeout: 0)
+
 test('memory-buffer', executable(
     'jetstream-memory-buffer', 'buffer.cc',
     dependencies: [libjetstream_dep, catch2_dep],

--- a/tests/memory/snapshot.cc
+++ b/tests/memory/snapshot.cc
@@ -1,0 +1,49 @@
+#define CATCH_CONFIG_RUNNER
+
+#include <string>
+#include <thread>
+
+#include <catch2/catch_all.hpp>
+
+#include "jetstream/types.hh"
+#include "jetstream/tools/snapshot.hh"
+
+using namespace Jetstream;
+
+int main(int argc, char* argv[]) {
+    return Catch::Session().run(argc, argv);
+}
+
+TEST_CASE("Snapshot stores and reads trivial values", "[snapshot][trivial]") {
+    Tools::Snapshot<U64> value(42);
+
+    REQUIRE(value.get() == 42);
+
+    value.publish(99);
+
+    REQUIRE(value.get() == 99);
+}
+
+TEST_CASE("Snapshot stores and reads snapshot values", "[snapshot][snapshot]") {
+    Tools::Snapshot<std::string> value(std::string("alpha"));
+
+    REQUIRE(value.get() == "alpha");
+
+    value.publish(std::string("beta"));
+
+    REQUIRE(value.get() == "beta");
+}
+
+TEST_CASE("Snapshot supports cross-thread publication", "[snapshot][threading]") {
+    Tools::Snapshot<U64> value(0);
+
+    std::thread producer([&value]() {
+        for (U64 i = 1; i <= 1024; ++i) {
+            value.publish(i);
+        }
+    });
+
+    producer.join();
+
+    REQUIRE(value.get() == 1024);
+}


### PR DESCRIPTION
This creates a `Snapshot` class to share internal values externally. This was done with bare variables but it technically crosses thread boundaries. So I created this Surface class to do this atomically.