### PR TITLE
^= catch >= v3.5.0 catchorg/Catch2#2722

### DIFF
--- a/meson/tools/catch2/meson.build
+++ b/meson/tools/catch2/meson.build
@@ -4,7 +4,7 @@ if not jst_is_ios and \
     catch2_dep = dependency(
         'catch2', 
         fallback: 'catch2', 
-        version: '>=3.0.0', 
+        version: '>=3.5.0', 
         required: false, 
         default_options: [
             'default_library=static',


### PR DESCRIPTION
otherwise possibly a number of header files missing if found installed on system from prior cyberether build and install