### PR TITLE
feat: show tensor info in output pin tooltip

### DIFF
--- a/include/jetstream/render/sakura/node/pin.hh
+++ b/include/jetstream/render/sakura/node/pin.hh
@@ -20,6 +20,9 @@ struct NodePin : public Component {
         std::string label;
         std::string help;
         bool enableDetach = false;
+        Shape dataShape;
+        DataType dataType;
+        DeviceType dataDevice;
     };
 
     NodePin();

--- a/src/compositor/default/views/flowgraph/editor/node.hh
+++ b/src/compositor/default/views/flowgraph/editor/node.hh
@@ -246,6 +246,9 @@ struct FlowgraphNode : public Sakura::Component {
                 .label = input.port.label,
                 .help = input.port.help,
                 .enableDetach = true,
+                .dataShape = Shape(),
+                .dataType = DataType::None,
+                .dataDevice = block.device
             });
         }
         for (const auto& output : block.outputs) {
@@ -254,6 +257,9 @@ struct FlowgraphNode : public Sakura::Component {
                 .direction = Sakura::NodePin::Direction::Output,
                 .label = output.port.label,
                 .help = output.port.help,
+                .dataShape = output.tensor.shape(),
+                .dataType = output.tensor.dtype(),
+                .dataDevice = output.tensor.device()
             });
         }
 

--- a/src/render/sakura/node/pin.cc
+++ b/src/render/sakura/node/pin.cc
@@ -1,5 +1,6 @@
 #include <jetstream/render/sakura/node/pin.hh>
 
+#include <jetstream/render/sakura/table.hh>
 #include <jetstream/render/sakura/text.hh>
 #include <jetstream/render/sakura/tooltip.hh>
 
@@ -12,6 +13,9 @@ struct NodePin::Impl {
     Text label;
     Text help;
     Tooltip helpTooltip;
+    bool tensorTooltip;
+    Text tensorSection;
+    Table tensorMetadataTable;
 };
 
 NodePin::NodePin() {
@@ -39,6 +43,27 @@ bool NodePin::update(Config config) {
         .id = id + "HelpTooltip",
         .wrapWidth = 560.0f,
     });
+    impl->tensorTooltip = false;
+    if (impl->config.dataShape.size() > 0) {
+        impl->tensorTooltip = true;
+        impl->tensorSection.update({
+            .id = impl->config.id + ":tooltip:tensor-section",
+            .str = "Layout",
+            .font = Sakura::Text::Font::Bold,
+        });
+        impl->tensorMetadataTable.update({
+            .id = impl->config.id + ":tooltip:tensor-table",
+            .columns = {"", ""},
+            .rows = {
+                {"Device", jst::fmt::format("{}", impl->config.dataDevice)},
+                {"Type", jst::fmt::format("{}", impl->config.dataType)},
+                {"Shape", jst::fmt::format("{}", impl->config.dataShape)}
+            },
+            .fixedColumnWidths = {72.0f},
+            .showHeaders = false,
+            .wrapped = true,
+        });
+    }
     return true;
 }
 
@@ -50,6 +75,10 @@ void NodePin::render(const Context& ctx) const {
         if (!config.help.empty()) {
             impl->helpTooltip.render(ctx, [this](const Context& ctx) {
                 this->impl->help.render(ctx);
+                if (this->impl->tensorTooltip) {
+                    this->impl->tensorSection.render(ctx);
+                    this->impl->tensorMetadataTable.render(ctx);
+                }
             });
         }
     };


### PR DESCRIPTION
borrowing from the tooltip for link, this reveals info beforehand

<img width="399" height="235" alt="image" src="https://github.com/user-attachments/assets/a2a8efbb-ead5-4b14-8735-ce2d15754810" />
