### PR TITLE
fix: cyberether dependency in example plugin

### DIFF
--- a/examples/plugins/blueprint/meson.build
+++ b/examples/plugins/blueprint/meson.build
@@ -10,7 +10,7 @@ project(
 )
 
 cyberether_dep = dependency(
-    'cyberether',
+    'jetstream',
     required: false,
     fallback: ['cyberether', 'libjetstream_dep'],
 )


### PR DESCRIPTION
Otherwise an installation of the Cyberether project, which installs the `libjetstream.so` isn't found when compiling a plugin project, and the whole of Cyberether is compiled unnecessarily...