### PR TITLE
feat: overhaul the native command-line interface

### DIFF
--- a/apps/linux/create-appimage.sh
+++ b/apps/linux/create-appimage.sh
@@ -140,7 +140,7 @@ write_desktop_file() {
 Type=Application
 Name=$APP_NAME
 Comment=CyberEther signal processing runtime
-Exec=$EXECUTABLE_NAME %F
+Exec=$EXECUTABLE_NAME %f
 Icon=$ICON_NAME
 Terminal=false
 Categories=Science;Engineering;

--- a/docs/installing-plugins.md
+++ b/docs/installing-plugins.md
@@ -43,6 +43,22 @@ CyberEther loads the plugin immediately and shows a "Plugin loaded." notificatio
 
 From now on, the plugin loads automatically every time CyberEther starts. If a plugin fails to load at startup, CyberEther logs a warning and continues starting normally.
 
+## Loading Plugins Temporarily
+
+Use the repeatable `--plugin` option to load one or more bundles for only the current process:
+
+```bash
+cyberether --plugin path/to/first.cep --plugin path/to/second.cep
+```
+
+The option also works with benchmarks, including benchmarks registered by a plugin:
+
+```bash
+cyberether benchmark custom_block --plugin path/to/plugin.cep
+```
+
+Command-line plugins are loaded in addition to registered plugins for that run. They are not added to the registry or saved in `settings.yaml`. If an explicitly requested bundle fails to load, the command exits with an error.
+
 ## Using The Plugin
 
 The plugin's blocks appear in the block catalog alongside the built-in blocks. Add them to a flowgraph the same way you add any other block.
@@ -84,4 +100,4 @@ The exact reason is printed to the log. Run CyberEther from a terminal and look 
 A few limitations to be aware of:
 
 - Plugins are not supported in the browser version of CyberEther.
-- There is no command line flag for loading plugins. Registration happens through the preferences window and persists across sessions.
+- Command-line plugins are temporary. Register a plugin through the preferences window to load it automatically in future sessions.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -14,14 +14,14 @@ The primary target. CyberEther runs as a plain native binary with direct access 
 ```
 cyberether [options] [flowgraph]
 cyberether run [options] [flowgraph]
-cyberether benchmark [options]
+cyberether benchmark [options] [block]
 ```
 
 The default command launches the full application and `benchmark` runs the benchmark suite. The graphics options prefer a renderer (`--renderer metal` or `--renderer vulkan`, with fallback to an available backend), control viewport geometry (`--size`, `--scale`, `--framerate`), and let `--headless` run without a window entirely. Passing one flowgraph file as a positional argument loads it at startup, which combined with `--headless` is the deployment shape for unattended machines.
 
 Long options with values accept either `--option value` or `--option=value`. Use `--` to treat every following argument as positional, such as for a flowgraph path beginning with a dash. Run `cyberether --help` or `cyberether run --help` for the complete option list.
 
-The benchmark command accepts `--format markdown`, `--format json`, or `--format csv` to select its output format. Run `cyberether benchmark --help` for its command-specific help.
+The benchmark command accepts `--format markdown`, `--format json`, or `--format csv` to select its output format. Pass a block type such as `fft` to run only that block's benchmarks: `cyberether benchmark fft --format json`. Run `cyberether benchmark --help` for its command-specific help.
 
 Quirks:
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -12,10 +12,16 @@ The same CyberEther runs in three shapes: as a native application on your machin
 The primary target. CyberEther runs as a plain native binary with direct access to the GPU and every backend the platform provides:
 
 ```
-cyberether [command] [options] [flowgraph]
+cyberether [options] [flowgraph]
+cyberether run [options] [flowgraph]
+cyberether benchmark [options]
 ```
 
-The default command runs the full application and `benchmark` runs the benchmark suite. The graphics options select the render device (`--device metal` or `--device vulkan`), the window geometry (`--size`, `--scale`, `--framerate`), and `--headless` runs without a window entirely. Passing a flowgraph file loads it at startup, which combined with `--headless` is the deployment shape for unattended machines.
+The default command launches the full application and `benchmark` runs the benchmark suite. The graphics options prefer a renderer (`--renderer metal` or `--renderer vulkan`, with fallback to an available backend), control viewport geometry (`--size`, `--scale`, `--framerate`), and let `--headless` run without a window entirely. Passing one flowgraph file as a positional argument loads it at startup, which combined with `--headless` is the deployment shape for unattended machines.
+
+Long options with values accept either `--option value` or `--option=value`. Use `--` to treat every following argument as positional, such as for a flowgraph path beginning with a dash. Run `cyberether --help` or `cyberether run --help` for the complete option list.
+
+The benchmark command accepts `--format markdown`, `--format json`, or `--format csv` to select its output format. Run `cyberether benchmark --help` for its command-specific help.
 
 Quirks:
 
@@ -37,16 +43,20 @@ Quirks:
 
 ## Remote
 
-A remote instance is a native CyberEther, usually headless on a server, that streams its interface to you and takes interaction back, so the full application runs at the remote machine's compute capacity. This platform will be available soon.
+A remote instance is a native CyberEther, usually headless on a server, that streams its interface to you and takes interaction back, so the full application runs at the remote machine's compute capacity. CyberEther Remote is a mode of the native application rather than a separate command:
+
+```
+cyberether --remote --broker https://cyberether.org [flowgraph]
+```
 
 ## Picking One
 
-| | Native | Web |
-|---|---|---|
-| Compute | Local, all backends | In-browser, CPU via WebAssembly |
-| Hardware access | Full | Browser APIs only |
-| Python blocks | Yes | No |
-| Install required | Yes | No |
-| Best for | Daily use, development, deployment | Trying it, demos, sharing |
+| | Native | Web | Remote |
+|---|---|---|---|
+| Compute | Local, all backends | In-browser, CPU via WebAssembly | Remote machine, all native backends |
+| Hardware access | Full | Browser APIs only | Full access on the remote machine |
+| Python blocks | Yes | No | Yes |
+| Install required | Yes | No | On the remote machine |
+| Best for | Daily use, development, deployment | Trying it, demos, sharing | Headless and high-performance systems |
 
-The rule of thumb: develop and deploy native, share via web, and stream from big hardware once remote lands.
+The rule of thumb: develop and deploy native, share via web, and use CyberEther Remote to stream from larger or unattended systems.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -17,11 +17,11 @@ cyberether run [options] [flowgraph]
 cyberether benchmark [options] [block]
 ```
 
-The default command launches the full application and `benchmark` runs the benchmark suite. The graphics options prefer a renderer (`--renderer metal` or `--renderer vulkan`, with fallback to an available backend), control viewport geometry (`--size`, `--scale`, `--framerate`), and let `--headless` run without a window entirely. Passing one flowgraph file as a positional argument loads it at startup, which combined with `--headless` is the deployment shape for unattended machines.
+The default command launches the full application and `benchmark` runs the benchmark suite. The graphics options prefer a renderer (`--renderer metal` or `--renderer vulkan`, with fallback to an available backend), select the zero-based Vulkan and CUDA device ordinal with `--device-index`, control viewport geometry (`--size`, `--scale`, `--framerate`), and let `--headless` run without a window entirely. Passing one flowgraph file as a positional argument loads it at startup, which combined with `--headless` is the deployment shape for unattended machines. Vulkan and CUDA enumerate devices independently, so the same ordinal is not guaranteed to identify the same physical GPU in both APIs.
 
 Long options with values accept either `--option value` or `--option=value`. Use `--` to treat every following argument as positional, such as for a flowgraph path beginning with a dash. Run `cyberether --help` or `cyberether run --help` for the complete option list.
 
-The benchmark command accepts `--format markdown`, `--format json`, or `--format csv` to select its output format. Pass a block type such as `fft` to run only that block's benchmarks: `cyberether benchmark fft --format json`. Run `cyberether benchmark --help` for its command-specific help.
+The benchmark command accepts `--format markdown`, `--format json`, or `--format csv` to select its output format. Pass a block type such as `fft` to run only that block's benchmarks: `cyberether benchmark fft --format json`. The CUDA benchmarks honor the global `--device-index` selection. Run `cyberether benchmark --help` for its command-specific help.
 
 Quirks:
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -17,7 +17,7 @@ cyberether
 
 This opens the main window with an empty workspace. From there you can build a flowgraph visually or load an existing one.
 
-To load a flowgraph directly at startup, pass its path as the last argument:
+To load a flowgraph directly at startup, pass its path as the single positional argument:
 
 ```bash
 cyberether examples/flowgraphs/signal-generator.yml

--- a/include/jetstream/backend/base.hh
+++ b/include/jetstream/backend/base.hh
@@ -82,6 +82,15 @@ struct GetBackend<DeviceType::CUDA> {
 
 class JETSTREAM_API Instance {
  public:
+    Result configure(const DeviceType& id, const Config& config) {
+        std::lock_guard lock(mutex);
+        if (backends.contains(id)) {
+            return Result::SUCCESS;
+        }
+        configurations[id] = config;
+        return Result::SUCCESS;
+    }
+
     template<DeviceType DeviceId>
     Result initialize(const Config& config) {
         using BackendType = typename GetBackend<DeviceId>::Type;
@@ -106,10 +115,10 @@ class JETSTREAM_API Instance {
     const auto& state() {
         using BackendType = typename GetBackend<DeviceId>::Type;
         if (!backends.contains(DeviceId)) {
-            JST_WARN("The {} backend is not initialized. Initializing with default headless settings.", DeviceId);
-
-            Backend::Config config;
-            config.headless = true;
+            Backend::Config config = configurations.contains(DeviceId)
+                ? configurations.at(DeviceId)
+                : Backend::Config{.headless = true};
+            JST_WARN("The {} backend is not initialized. Initializing with configured settings.", DeviceId);
             JST_CHECK_THROW(initialize<DeviceId>(config));
         }
         return std::get<std::unique_ptr<BackendType>>(backends[DeviceId]);
@@ -121,6 +130,7 @@ class JETSTREAM_API Instance {
 
     Result destroyAll() {
         backends.clear();
+        configurations.clear();
         return Result::SUCCESS;
     }
 
@@ -144,6 +154,7 @@ class JETSTREAM_API Instance {
     > BackendHolder;
 
     std::unordered_map<DeviceType, BackendHolder> backends;
+    std::unordered_map<DeviceType, Config> configurations;
     std::mutex mutex;
 };
 
@@ -152,6 +163,11 @@ JETSTREAM_API Instance& Get();
 template<DeviceType D>
 const auto& State() {
     return Get().state<D>();
+}
+
+template<DeviceType D>
+Result Configure(const Config& config) {
+    return Get().configure(D, config);
 }
 
 template<DeviceType D>

--- a/include/jetstream/backend/devices/cuda/base.hh
+++ b/include/jetstream/backend/devices/cuda/base.hh
@@ -14,6 +14,7 @@ class CUDA {
     explicit CUDA(const Config& config);
     ~CUDA();
 
+    Result activate() const;
     bool isAvailable() const;
     std::string getDeviceName() const;
     std::string getApiVersion() const;

--- a/include/jetstream/benchmark.hh
+++ b/include/jetstream/benchmark.hh
@@ -40,6 +40,9 @@ class JETSTREAM_API Benchmark {
     using ResultMapType = std::map<std::string, std::vector<Measurement>>;
 
     static void Run(const std::string& outputType, std::ostream& out = std::cout);
+    static void Run(const std::string& outputType,
+                    const std::string& blockType,
+                    std::ostream& out = std::cout);
     static U64 TotalCount();
     static U64 CurrentCount();
     static void ResetResults();

--- a/include/jetstream/instance.hh
+++ b/include/jetstream/instance.hh
@@ -23,6 +23,7 @@ class JETSTREAM_API Instance : public std::enable_shared_from_this<Instance> {
 
     struct Config {
         std::optional<DeviceType> device{};
+        U64 deviceId{0};
         std::optional<CompositorType> compositor{};
         bool headless{false};
         Extent2D<U64> size{1920, 1080};

--- a/include/jetstream/settings.hh
+++ b/include/jetstream/settings.hh
@@ -20,6 +20,7 @@ struct JETSTREAM_API Settings {
 
     struct Graphics {
         std::optional<DeviceType> device{};
+        U64 deviceId = 0;
         bool headless = false;
         Size size;
         F32 scale = 1.0f;

--- a/src/backend/devices/cuda/base.cc
+++ b/src/backend/devices/cuda/base.cc
@@ -136,6 +136,16 @@ CUDA::~CUDA() {
     }
 }
 
+Result CUDA::activate() const {
+    JST_CUDA_CHECK(cudaSetDevice(config.deviceId), [&]{
+        JST_ERROR("[CUDA] Cannot activate device ID ({}): {}", config.deviceId, err);
+    });
+    JST_CUDA_CHECK(cuCtxSetCurrent(context), [&]{
+        JST_ERROR("[CUDA] Cannot activate context for device ID ({}): {}", config.deviceId, err);
+    });
+    return Result::SUCCESS;
+}
+
 bool CUDA::isAvailable() const {
     return _isAvailable;
 }

--- a/src/backend/devices/cuda/base.cc
+++ b/src/backend/devices/cuda/base.cc
@@ -20,7 +20,8 @@ CUDA::CUDA(const Config& config) : config(config), cache({}) {
         JST_FATAL("[CUDA] Cannot get device count: {}", err);
     });
     if (config.deviceId >= static_cast<U64>(deviceCount)) {
-       JST_FATAL("[CUDA] Cannot get desired device ID ({}).", config.deviceId);
+        JST_FATAL("[CUDA] Cannot get desired device ID ({}).", config.deviceId);
+        JST_CHECK_THROW(Result::ERROR);
     }
 
     // Setup device.
@@ -117,6 +118,7 @@ CUDA::CUDA(const Config& config) : config(config), cache({}) {
     JST_INFO("-----------------------------------------------------");
     JST_INFO("Jetstream Heterogeneous Backend [CUDA]")
     JST_INFO("-----------------------------------------------------");
+    JST_INFO("Device ID:          {}", getDeviceId());
     JST_INFO("Device Name:        {}", getDeviceName());
     JST_INFO("Device Type:        {}", getPhysicalDeviceType());
     JST_INFO("API Version:        {}", getApiVersion());

--- a/src/backend/devices/vulkan/base.cc
+++ b/src/backend/devices/vulkan/base.cc
@@ -286,10 +286,14 @@ Vulkan::Vulkan(const Config& _config) : config(_config), cache({}) {
         }
 
         std::vector<VkPhysicalDevice> physicalDevices(physicalDeviceCount);
-        vkEnumeratePhysicalDevices(instance, &physicalDeviceCount, physicalDevices.data());
+        JST_VK_CHECK_THROW(vkEnumeratePhysicalDevices(instance, &physicalDeviceCount, physicalDevices.data()), [&]{
+            JST_FATAL("[VULKAN] Can't enumerate physical devices.");
+        });
 
         std::vector<VkPhysicalDevice> validPhysicalDevices;
         for (const auto& candidatePhysicalDevice : physicalDevices) {
+            VkPhysicalDeviceProperties candidateProperties;
+            vkGetPhysicalDeviceProperties(candidatePhysicalDevice, &candidateProperties);
             const auto& requiredExtensions = getRequiredDeviceExtensions();
             const auto& supportedExtensions = checkDeviceExtensionSupport(candidatePhysicalDevice, requiredExtensions);
             const auto& extensionCheck = requiredExtensions.size() == supportedExtensions.size();
@@ -297,10 +301,14 @@ Vulkan::Vulkan(const Config& _config) : config(_config), cache({}) {
             const auto& queueFamilyIndices = FindQueueFamilies(candidatePhysicalDevice);
             const auto& queueFamilyCheck = queueFamilyIndices.isComplete();
 
-            JST_DEBUG("[VULKAN] Candidate device - Extension check: {}, Queue family check: {}",
+            JST_DEBUG("[VULKAN] Candidate device '{}' - Extension check: {}, Queue family check: {}",
+                      candidateProperties.deviceName,
                       extensionCheck ? "OK" : "FAIL", queueFamilyCheck ? "OK" : "FAIL");
 
             if (extensionCheck && queueFamilyCheck) {
+                JST_DEBUG("[VULKAN] Device ID {}: {}",
+                          validPhysicalDevices.size(),
+                          candidateProperties.deviceName);
                 validPhysicalDevices.push_back(candidatePhysicalDevice);
             }
         }
@@ -309,7 +317,7 @@ Vulkan::Vulkan(const Config& _config) : config(_config), cache({}) {
             JST_CHECK_THROW(Result::FATAL);
         }
         if (validPhysicalDevices.size() <= config.deviceId) {
-            JST_FATAL("[VULKAN] Can't find desired device ID.");
+            JST_FATAL("[VULKAN] Can't find desired device ID ({}).", config.deviceId);
             JST_CHECK_THROW(Result::FATAL);
         }
         physicalDevice = validPhysicalDevices[config.deviceId];
@@ -604,6 +612,7 @@ Vulkan::Vulkan(const Config& _config) : config(_config), cache({}) {
     JST_INFO("-----------------------------------------------------");
     JST_INFO("Jetstream Heterogeneous Backend [VULKAN]")
     JST_INFO("-----------------------------------------------------");
+    JST_INFO("Device ID:        {}", getDeviceId());
     JST_INFO("Device Name:      {}", getDeviceName());
     JST_INFO("Device Type:      {}", getPhysicalDeviceType());
     JST_INFO("API Version:      {}", getApiVersion());

--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -15,7 +15,9 @@
 namespace Jetstream {
 
 struct Benchmark::Impl {
-    void run(const std::string& outputType, std::ostream& out);
+    void run(const std::string& outputType,
+             const std::string& blockType,
+             std::ostream& out);
     U64 totalCount();
     U64 currentCount();
     void resetResults();
@@ -29,7 +31,9 @@ Benchmark::Impl& Benchmark::benchmark() {
     return impl;
 }
 
-void Benchmark::Impl::run(const std::string& outputType, std::ostream& out) {
+void Benchmark::Impl::run(const std::string& outputType,
+                          const std::string& blockType,
+                          std::ostream& out) {
     using namespace ankerl;
     using namespace std::chrono_literals;
 
@@ -46,7 +50,7 @@ void Benchmark::Impl::run(const std::string& outputType, std::ostream& out) {
 
     resetResults();
 
-    for (const auto& benchmark : Registry::ListAvailableBenchmarks()) {
+    for (const auto& benchmark : Registry::ListAvailableBenchmarks(blockType)) {
         const auto specs = benchmark.factory();
         if (specs.empty()) {
             continue;
@@ -186,7 +190,13 @@ const Benchmark::ResultMapType& Benchmark::Impl::getResults() {
 }
 
 void Benchmark::Run(const std::string& outputType, std::ostream& out) {
-    benchmark().run(outputType, out);
+    benchmark().run(outputType, "", out);
+}
+
+void Benchmark::Run(const std::string& outputType,
+                    const std::string& blockType,
+                    std::ostream& out) {
+    benchmark().run(outputType, blockType, out);
 }
 
 U64 Benchmark::TotalCount() {

--- a/src/compositor/default/presenters/modal/settings/about.hh
+++ b/src/compositor/default/presenters/modal/settings/about.hh
@@ -64,6 +64,7 @@ inline std::vector<AboutInfoTable::Config> BuildAboutInfoTables(const AboutPrese
             .title = "CUDA Backend",
             .rows = {
                 {"Device", backend->getDeviceName()},
+                {"Device Index", jst::fmt::format("{}", backend->getDeviceId())},
                 {"API Version", backend->getApiVersion()},
                 {"Compute Capability", backend->getComputeCapability()},
                 {"Physical Memory", jst::fmt::format("{:.0f} GB", static_cast<float>(backend->getPhysicalMemory()) / (1024 * 1024 * 1024))},
@@ -103,6 +104,7 @@ inline std::vector<AboutInfoTable::Config> BuildAboutInfoTables(const AboutPrese
             .title = "Vulkan Backend",
             .rows = {
                 {"Device", backend->getDeviceName()},
+                {"Device Index", jst::fmt::format("{}", backend->getDeviceId())},
                 {"API Version", backend->getApiVersion()},
                 {"Physical Memory", jst::fmt::format("{:.0f} GB", static_cast<float>(backend->getPhysicalMemory()) / (1024 * 1024 * 1024))},
                 {"Unified Memory", backend->hasUnifiedMemory() ? "Yes" : "No"},

--- a/src/instance.cc
+++ b/src/instance.cc
@@ -70,6 +70,7 @@ Result Instance::create(const Config& config) {
 
     {
         auto backendConfig = Backend::Config {
+            .deviceId = config.deviceId,
             .headless = config.headless,
             .pythonRuntimePath = config.pythonRuntimePath,
         };
@@ -83,6 +84,9 @@ Result Instance::create(const Config& config) {
 
 #ifdef JETSTREAM_BACKEND_CPU_AVAILABLE
         JST_CHECK(Backend::Initialize<DeviceType::CPU>(backendConfig));
+#endif
+#ifdef JETSTREAM_BACKEND_CUDA_AVAILABLE
+        JST_CHECK(Backend::Configure<DeviceType::CUDA>(backendConfig));
 #endif
 
 #ifdef JETSTREAM_VIEWPORT_GLFW_AVAILABLE

--- a/src/run_native.cc
+++ b/src/run_native.cc
@@ -6,6 +6,7 @@
 #include <optional>
 #include <string_view>
 #include <thread>
+#include <vector>
 
 #include "jetstream/run.hh"
 #include "jetstream/config.hh"
@@ -226,8 +227,9 @@ static void printUsage(const char* program,
     jst::fmt::print("  -h, --help                   Show this help\n");
     jst::fmt::print("  -v, -vv                      Set debug or trace log level\n");
     jst::fmt::print("  -V, --version                Show version\n");
-    jst::fmt::print("  --device-index <index>       Vulkan and CUDA device index (current: {})\n\n",
+    jst::fmt::print("  --device-index <index>       Vulkan and CUDA device index (current: {})\n",
                     settings.graphics.deviceId);
+    jst::fmt::print("  --plugin <path>              Load a .cep plugin (repeatable)\n\n");
 
     if (!command.has_value() || *command == CommandType::Run) {
         jst::fmt::print("Graphics Options:\n");
@@ -308,6 +310,7 @@ int Run(int argc, char* argv[], PluginCreateFn pluginCreate, PluginDestroyFn plu
     std::string remoteSettingOption;
     std::string benchmarkOption;
     std::string benchmarkFilter;
+    std::vector<std::string> commandLinePlugins;
     bool positionalOnly = false;
 
     for (int i = 1; i < argc; i++) {
@@ -396,6 +399,15 @@ int Run(int argc, char* argv[], PluginCreateFn pluginCreate, PluginDestroyFn plu
             }
             jst::fmt::print("CyberEther v{}-{}\n", JETSTREAM_VERSION_STR, JETSTREAM_BUILD_TYPE);
             return 0;
+        }
+
+        if (!positionalOnly && arg == "--plugin") {
+            std::string value;
+            if (!takeValue(value)) {
+                return PrintUsageError(argv[0], "Missing value for --plugin. Expected a .cep path.");
+            }
+            commandLinePlugins.push_back(value);
+            continue;
         }
 
         if (!positionalOnly && arg == "-v") {
@@ -661,6 +673,12 @@ int Run(int argc, char* argv[], PluginCreateFn pluginCreate, PluginDestroyFn plu
 #endif
 
     LoadRegistryPlugins(settings);
+    for (const auto& path : commandLinePlugins) {
+        if (Plugin::Load(path) != Result::SUCCESS) {
+            jst::fmt::print(stderr, "Error: Failed to load command-line plugin '{}'.\n", path);
+            return -1;
+        }
+    }
 
     //
     // Benchmark Logic

--- a/src/run_native.cc
+++ b/src/run_native.cc
@@ -251,6 +251,7 @@ int Run(int argc, char* argv[], PluginCreateFn pluginCreate, PluginDestroyFn plu
         settings = {};
         (void)Settings::Set(settings, false);
     }
+    const Settings retainedSettings = settings;
 
     JST_LOG_SET_DEBUG_LEVEL(settings.developer.logLevel);
 
@@ -616,7 +617,15 @@ int Run(int argc, char* argv[], PluginCreateFn pluginCreate, PluginDestroyFn plu
 
         instance = std::make_shared<Instance>();
 
-        if (instance->create(config) != Result::SUCCESS) {
+        const Result createResult = instance->create(config);
+
+        // The compositor initializes from the effective CLI settings. Restore
+        // retained settings before later UI changes can persist CLI overrides.
+        if (Settings::Set(retainedSettings, false) != Result::SUCCESS) {
+            return -1;
+        }
+
+        if (createResult != Result::SUCCESS) {
             return -1;
         }
 

--- a/src/run_native.cc
+++ b/src/run_native.cc
@@ -13,6 +13,7 @@
 #include "jetstream/instance.hh"
 #include "jetstream/instance_remote.hh"
 #include "jetstream/plugin.hh"
+#include "jetstream/registry.hh"
 #include "jetstream/backend/base.hh"
 #include "jetstream/benchmark.hh"
 
@@ -177,12 +178,12 @@ static void printUsage(const char* program,
     if (!command.has_value()) {
         jst::fmt::print("  {} [options] [flowgraph]\n", program);
         jst::fmt::print("  {} run [options] [flowgraph]\n", program);
-        jst::fmt::print("  {} benchmark [options]\n\n", program);
+        jst::fmt::print("  {} benchmark [options] [block]\n\n", program);
         jst::fmt::print("Commands:\n");
         jst::fmt::print("  run                          Launch CyberEther (default)\n");
         jst::fmt::print("  benchmark                    Run performance benchmarks\n\n");
     } else if (*command == CommandType::Benchmark) {
-        jst::fmt::print("  {} benchmark [options]\n\n", program);
+        jst::fmt::print("  {} benchmark [options] [block]\n\n", program);
     } else {
         jst::fmt::print("  {} run [options] [flowgraph]\n\n", program);
     }
@@ -236,7 +237,7 @@ static void printUsage(const char* program,
         jst::fmt::print("  {} --remote flowgraph.yaml\n", program);
     }
     if (!command.has_value() || *command == CommandType::Benchmark) {
-        jst::fmt::print("  {} benchmark --format json\n", program);
+        jst::fmt::print("  {} benchmark fft --format json\n", program);
     }
 }
 
@@ -270,6 +271,7 @@ int Run(int argc, char* argv[], PluginCreateFn pluginCreate, PluginDestroyFn plu
     std::string runOption;
     std::string remoteSettingOption;
     std::string benchmarkOption;
+    std::string benchmarkFilter;
     bool positionalOnly = false;
 
     for (int i = 1; i < argc; i++) {
@@ -545,8 +547,12 @@ int Run(int argc, char* argv[], PluginCreateFn pluginCreate, PluginDestroyFn plu
         }
 
         if (command == CommandType::Benchmark) {
-            return PrintUsageError(argv[0], jst::fmt::format(
-                "The benchmark command does not accept a flowgraph: '{}'.", originalArg));
+            if (!benchmarkFilter.empty()) {
+                return PrintUsageError(argv[0], jst::fmt::format(
+                    "Only one benchmark block may be provided; received '{}'.", originalArg));
+            }
+            benchmarkFilter = Lowercase(originalArg);
+            continue;
         }
 
         if (!flowgraphPath.empty()) {
@@ -600,7 +606,12 @@ int Run(int argc, char* argv[], PluginCreateFn pluginCreate, PluginDestroyFn plu
     //
 
     if (command == CommandType::Benchmark) {
-        Benchmark::Run(settings.benchmark.format);
+        if (!benchmarkFilter.empty() &&
+            Registry::ListAvailableBenchmarks(benchmarkFilter).empty()) {
+            return PrintUsageError(argv[0], jst::fmt::format(
+                "No benchmarks found for block '{}'.", benchmarkFilter));
+        }
+        Benchmark::Run(settings.benchmark.format, benchmarkFilter);
         return 0;
     }
 

--- a/src/run_native.cc
+++ b/src/run_native.cc
@@ -151,6 +151,23 @@ int PrintUsageError(const char* program, const std::string& message) {
     return CLI_USAGE_ERROR;
 }
 
+class LogLevelGuard {
+ public:
+    explicit LogLevelGuard(int level) : previous_(_JST_LOG_DEBUG_LEVEL()) {
+        JST_LOG_SET_DEBUG_LEVEL(level);
+    }
+
+    LogLevelGuard(const LogLevelGuard&) = delete;
+    LogLevelGuard& operator=(const LogLevelGuard&) = delete;
+
+    ~LogLevelGuard() {
+        JST_LOG_SET_DEBUG_LEVEL(previous_);
+    }
+
+ private:
+    int previous_;
+};
+
 }  // namespace
 
 static void printUsage(const char* program,
@@ -585,6 +602,11 @@ int Run(int argc, char* argv[], PluginCreateFn pluginCreate, PluginDestroyFn plu
         } catch (const Result&) {
             return PrintUsageError(argv[0], "The configured CyberEther Remote codec or encoder is invalid.");
         }
+    }
+
+    std::optional<LogLevelGuard> benchmarkLogLevel;
+    if (command == CommandType::Benchmark) {
+        benchmarkLogLevel.emplace(-1);
     }
 
     JST_INFO("[CYBERETHER] Running native app.");

--- a/src/run_native.cc
+++ b/src/run_native.cc
@@ -1,5 +1,10 @@
 #include <algorithm>
+#include <cctype>
+#include <cmath>
 #include <cstdio>
+#include <limits>
+#include <optional>
+#include <string_view>
 #include <thread>
 
 #include "jetstream/run.hh"
@@ -77,49 +82,168 @@ std::string RemoteEncoderOptionsString() {
     return options;
 }
 
-}  // namespace
-
-void printUsage(const char* program) {
-    const std::string codecOptions = RemoteCodecOptionsString();
-    const std::string encoderOptions = RemoteEncoderOptionsString();
-
-    jst::fmt::print("Usage: {} [command] [options] [flowgraph]\n\n", program);
-    jst::fmt::print("Commands:\n");
-    jst::fmt::print("  run                          Run normally (default)\n");
-    jst::fmt::print("  remote                       Run with remote streaming enabled\n");
-    jst::fmt::print("  benchmark                    Run benchmarks\n\n");
-    jst::fmt::print("Global Options:\n");
-    jst::fmt::print("  -h, --help                   Show this help\n");
-    jst::fmt::print("  -v, -vv                      Increase log verbosity (debug, trace)\n");
-    jst::fmt::print("  -V, --version                Show version\n\n");
-    jst::fmt::print("Graphics Options:\n");
-    jst::fmt::print("  --device <type>              Device type (metal, vulkan)\n");
-    jst::fmt::print("  --device-id <id>             Device ID (default: 0)\n");
-    jst::fmt::print("  --headless                   Run in headless mode (no window)\n");
-    jst::fmt::print("  --size <WxH>                 Window size (default: 1920x1080)\n");
-    jst::fmt::print("  --scale <scale>              Interface scale factor (default: 1.0)\n");
-    jst::fmt::print("  --framerate <fps>            Target framerate (default: 60)\n\n");
-    jst::fmt::print("Benchmark Options:\n");
-    jst::fmt::print("  --format <type>             Output format: markdown, json, csv (default: markdown)\n\n");
-    jst::fmt::print("Remote Options:\n");
-    jst::fmt::print("  --endpoint <url>             Broker URL (default: https://cyberether.org)\n");
-    jst::fmt::print("  --auto-join                  Auto-join sessions\n");
-    jst::fmt::print("  --codec <codec>              Codec: {} (default: {})\n",
-                    codecOptions,
-                    GetRemoteCodecName(Instance::Remote::CodecType::H264));
-    jst::fmt::print("  --encoder <type>             Encoder: {} (default: {})\n",
-                    encoderOptions,
-                    GetRemoteEncoderName(Instance::Remote::EncoderType::Auto));
-}
-
 enum class CommandType {
     Run,
-    Remote,
     Benchmark,
 };
 
+constexpr int CLI_USAGE_ERROR = 2;
+constexpr U64 MAX_VIEWPORT_DIMENSION = static_cast<U64>(std::numeric_limits<I32>::max());
+
+std::string Lowercase(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return value;
+}
+
+bool IsRemoteCodec(const std::string& value) {
+    return std::any_of(RemoteCodecTypes.begin(), RemoteCodecTypes.end(), [&](const auto codec) {
+        return value == GetRemoteCodecName(codec);
+    });
+}
+
+bool IsRemoteEncoder(const std::string& value) {
+    return std::any_of(RemoteEncoderTypes.begin(), RemoteEncoderTypes.end(), [&](const auto encoder) {
+        return value == GetRemoteEncoderName(encoder);
+    });
+}
+
+bool ParsePositiveInteger(const std::string& value, U64& result) {
+    if (value.empty() || !std::all_of(value.begin(), value.end(), [](unsigned char c) {
+        return std::isdigit(c);
+    })) {
+        return false;
+    }
+
+    try {
+        size_t parsed = 0;
+        const U64 number = std::stoull(value, &parsed);
+        if (parsed != value.size() || number == 0) {
+            return false;
+        }
+        result = number;
+    } catch (const std::exception&) {
+        return false;
+    }
+
+    return true;
+}
+
+bool ParsePositiveFloat(const std::string& value, F32& result) {
+    try {
+        size_t parsed = 0;
+        const F32 number = std::stof(value, &parsed);
+        if (parsed != value.size() || !std::isfinite(number) || number <= 0.0f) {
+            return false;
+        }
+        result = number;
+    } catch (const std::exception&) {
+        return false;
+    }
+
+    return true;
+}
+
+int PrintUsageError(const char* program, const std::string& message) {
+    jst::fmt::print(stderr, "Error: {}\nTry '{} --help' for more information.\n", message, program);
+    return CLI_USAGE_ERROR;
+}
+
+}  // namespace
+
+static void printUsage(const char* program,
+                       const Settings& settings,
+                       const std::optional<CommandType> command = std::nullopt) {
+    const std::string codecOptions = RemoteCodecOptionsString();
+    const std::string encoderOptions = RemoteEncoderOptionsString();
+    const std::string renderer = settings.graphics.device.has_value()
+        ? GetDeviceName(*settings.graphics.device)
+        : "automatic";
+    std::string interfaceScale = jst::fmt::format("{}", settings.graphics.scale);
+    if (std::isfinite(settings.graphics.scale) && interfaceScale.find_first_of(".eE") == std::string::npos) {
+        interfaceScale += ".0";
+    }
+
+    std::string encoderChoicesFirst = encoderOptions;
+    std::string encoderChoicesSecond;
+    const size_t encoderWrap = encoderOptions.find(", videotoolbox");
+    if (encoderWrap != std::string::npos) {
+        encoderChoicesFirst = encoderOptions.substr(0, encoderWrap + 1);
+        encoderChoicesSecond = encoderOptions.substr(encoderWrap + 2);
+    }
+
+    jst::fmt::print("Usage:\n");
+    if (!command.has_value()) {
+        jst::fmt::print("  {} [options] [flowgraph]\n", program);
+        jst::fmt::print("  {} run [options] [flowgraph]\n", program);
+        jst::fmt::print("  {} benchmark [options]\n\n", program);
+        jst::fmt::print("Commands:\n");
+        jst::fmt::print("  run                          Launch CyberEther (default)\n");
+        jst::fmt::print("  benchmark                    Run performance benchmarks\n\n");
+    } else if (*command == CommandType::Benchmark) {
+        jst::fmt::print("  {} benchmark [options]\n\n", program);
+    } else {
+        jst::fmt::print("  {} run [options] [flowgraph]\n\n", program);
+    }
+
+    jst::fmt::print("Global Options:\n");
+    jst::fmt::print("  -h, --help                   Show this help\n");
+    jst::fmt::print("  -v, -vv                      Set debug or trace log level\n");
+    jst::fmt::print("  -V, --version                Show version\n\n");
+
+    if (!command.has_value() || *command == CommandType::Run) {
+        jst::fmt::print("Graphics Options:\n");
+        jst::fmt::print("  --renderer <renderer>        Preferred graphics backend (current: {})\n", renderer);
+        jst::fmt::print("  {:<29}  Choices: metal, vulkan\n", "");
+        jst::fmt::print("  --headless                   Run without a window\n");
+        jst::fmt::print("  --size <WxH>                 Viewport size (current: {}x{})\n",
+                        settings.graphics.size.width,
+                        settings.graphics.size.height);
+        jst::fmt::print("  --scale <factor>             Interface scale factor (current: {})\n",
+                        interfaceScale);
+        jst::fmt::print("  --framerate <fps>            Target frame rate (current: {})\n\n",
+                        settings.graphics.framerate);
+        jst::fmt::print("CyberEther Remote Options:\n");
+        jst::fmt::print("  --remote                     Enable CyberEther Remote\n");
+        jst::fmt::print("  --broker <url>               Broker URL (current: {})\n",
+                        settings.remote.brokerUrl);
+        jst::fmt::print("  --auto-join-sessions         Automatically join remote sessions\n");
+        jst::fmt::print("  --codec <codec>              Streaming codec (current: {})\n",
+                        settings.remote.codec);
+        jst::fmt::print("  {:<29}  Choices: {}\n", "", codecOptions);
+        jst::fmt::print("  --encoder <encoder>          Streaming encoder (current: {})\n",
+                        settings.remote.encoder);
+        jst::fmt::print("  {:<29}  Choices: {}\n", "", encoderChoicesFirst);
+        if (!encoderChoicesSecond.empty()) {
+            jst::fmt::print("  {:<29}           {}\n", "", encoderChoicesSecond);
+        }
+    }
+
+    if (!command.has_value() || *command == CommandType::Benchmark) {
+        if (!command.has_value()) {
+            jst::fmt::print("\n");
+        }
+        jst::fmt::print("Benchmark Options:\n");
+        jst::fmt::print("  --format <format>            Output format (current: {})\n",
+                        settings.benchmark.format);
+        jst::fmt::print("  {:<29}  Choices: markdown, json, csv\n", "");
+    }
+
+    jst::fmt::print("\nExamples:\n");
+    if (!command.has_value() || *command == CommandType::Run) {
+        jst::fmt::print("  {} flowgraph.yaml\n", program);
+        jst::fmt::print("  {} --remote flowgraph.yaml\n", program);
+    }
+    if (!command.has_value() || *command == CommandType::Benchmark) {
+        jst::fmt::print("  {} benchmark --format json\n", program);
+    }
+}
+
 int Run(int argc, char* argv[], PluginCreateFn pluginCreate, PluginDestroyFn pluginDestroy) {
     CommandType command = CommandType::Run;
+    bool commandSelected = false;
+    bool remoteEnabled = false;
 
     Settings settings;
     if (Settings::Get(settings) != Result::SUCCESS) {
@@ -142,47 +266,106 @@ int Run(int argc, char* argv[], PluginCreateFn pluginCreate, PluginDestroyFn plu
     // Parse Arguments
     //
 
+    std::string runOption;
+    std::string remoteSettingOption;
+    std::string benchmarkOption;
+    bool positionalOnly = false;
+
     for (int i = 1; i < argc; i++) {
-        const std::string arg = argv[i];
+        const std::string originalArg = argv[i];
+        std::string arg = originalArg;
+        std::optional<std::string> inlineValue;
+
+        if (!positionalOnly && originalArg != "--" && arg.starts_with("--")) {
+            const size_t separator = arg.find('=');
+            if (separator != std::string::npos) {
+                inlineValue = arg.substr(separator + 1);
+                arg = arg.substr(0, separator);
+            }
+        }
+
+        auto takeValue = [&](std::string& value) {
+            if (inlineValue.has_value()) {
+                if (inlineValue->empty()) {
+                    return false;
+                }
+                value = *inlineValue;
+                return true;
+            }
+
+            if (i + 1 >= argc || std::string_view(argv[i + 1]).starts_with("-")) {
+                return false;
+            }
+
+            value = argv[++i];
+            return !value.empty();
+        };
+
+        auto rejectInlineValue = [&]() {
+            return inlineValue.has_value()
+                ? PrintUsageError(argv[0], jst::fmt::format("Option '{}' does not accept a value.", arg))
+                : 0;
+        };
+
+        if (!positionalOnly && originalArg == "--") {
+            positionalOnly = true;
+            continue;
+        }
 
         // Handle Commands
 
-        if (i == 1) {
+        if (!positionalOnly && flowgraphPath.empty() && !commandSelected) {
             if (arg == "run") {
                 command = CommandType::Run;
-                continue;
-            }
-
-            if (arg == "remote") {
-                command = CommandType::Remote;
+                commandSelected = true;
                 continue;
             }
 
             if (arg == "benchmark") {
                 command = CommandType::Benchmark;
+                commandSelected = true;
                 continue;
             }
+
+            if (arg == "remote") {
+                return PrintUsageError(argv[0], "Unknown command: 'remote'.");
+            }
+
         }
 
         // Handle Global Options
 
-        if (arg == "-h" || arg == "--help") {
-            printUsage(argv[0]);
+        if (!positionalOnly && (arg == "-h" || arg == "--help")) {
+            if (const int error = rejectInlineValue()) {
+                return error;
+            }
+            std::optional<CommandType> helpCommand;
+            if (commandSelected || !flowgraphPath.empty()) {
+                helpCommand = command;
+            } else if (!runOption.empty()) {
+                helpCommand = CommandType::Run;
+            } else if (!benchmarkOption.empty()) {
+                helpCommand = CommandType::Benchmark;
+            }
+            printUsage(argv[0], settings, helpCommand);
             return 0;
         }
 
-        if (arg == "-V" || arg == "--version") {
+        if (!positionalOnly && (arg == "-V" || arg == "--version")) {
+            if (const int error = rejectInlineValue()) {
+                return error;
+            }
             jst::fmt::print("CyberEther v{}-{}\n", JETSTREAM_VERSION_STR, JETSTREAM_BUILD_TYPE);
             return 0;
         }
 
-        if (arg == "-v") {
+        if (!positionalOnly && arg == "-v") {
             settings.developer.logLevel = 3;
             JST_LOG_SET_DEBUG_LEVEL(settings.developer.logLevel);
             continue;
         }
 
-        if (arg == "-vv") {
+        if (!positionalOnly && arg == "-vv") {
             settings.developer.logLevel = 4;
             JST_LOG_SET_DEBUG_LEVEL(settings.developer.logLevel);
             continue;
@@ -190,146 +373,210 @@ int Run(int argc, char* argv[], PluginCreateFn pluginCreate, PluginDestroyFn plu
 
         // Handle Graphics Options
 
-        if (arg == "--device") {
-            if (i + 1 < argc) {
-                settings.graphics.device = StringToDevice(argv[++i]);
+        if (!positionalOnly && arg == "--renderer") {
+            std::string value;
+            if (!takeValue(value)) {
+                return PrintUsageError(argv[0], "Missing value for --renderer. Expected: metal or vulkan.");
             }
+            value = Lowercase(value);
+            if (value != "metal" && value != "vulkan") {
+                return PrintUsageError(argv[0], jst::fmt::format(
+                    "Invalid value for --renderer: '{}'. Expected: metal or vulkan.", value));
+            }
+            settings.graphics.device = StringToDevice(value);
+            runOption = arg;
             continue;
         }
 
-        if (arg == "--device-id") {
-            if (i + 1 < argc) {
-                ++i; // TODO: Implement device selection.
+        if (!positionalOnly && arg == "--headless") {
+            if (const int error = rejectInlineValue()) {
+                return error;
             }
-            continue;
-        }
-
-        if (arg == "--headless") {
             settings.graphics.headless = true;
+            runOption = arg;
             continue;
         }
 
-        if (arg == "--size") {
-            if (i + 1 < argc) {
-                std::string sizeStr = argv[++i];
-                size_t xPos = sizeStr.find('x');
-                if (xPos != std::string::npos) {
-                    settings.graphics.size.width = std::stoull(sizeStr.substr(0, xPos));
-                    settings.graphics.size.height = std::stoull(sizeStr.substr(xPos + 1));
-                }
+        if (!positionalOnly && arg == "--size") {
+            std::string value;
+            if (!takeValue(value)) {
+                return PrintUsageError(argv[0], "Missing value for --size. Expected: WIDTHxHEIGHT.");
             }
-            continue;
-        }
-
-        if (arg == "--scale") {
-            if (i + 1 < argc) {
-                settings.graphics.scale = std::stof(argv[++i]);
+            const size_t separator = value.find_first_of("xX");
+            U64 width = 0;
+            U64 height = 0;
+            if (separator == std::string::npos ||
+                value.find_first_of("xX", separator + 1) != std::string::npos ||
+                !ParsePositiveInteger(value.substr(0, separator), width) ||
+                !ParsePositiveInteger(value.substr(separator + 1), height) ||
+                width > MAX_VIEWPORT_DIMENSION ||
+                height > MAX_VIEWPORT_DIMENSION) {
+                return PrintUsageError(argv[0], jst::fmt::format(
+                    "Invalid value for --size: '{}'. Expected dimensions from 1 to {}.",
+                    value,
+                    MAX_VIEWPORT_DIMENSION));
             }
+            settings.graphics.size.width = width;
+            settings.graphics.size.height = height;
+            runOption = arg;
             continue;
         }
 
-        if (arg == "--framerate") {
-            if (i + 1 < argc) {
-                settings.graphics.framerate = std::stoull(argv[++i]);
+        if (!positionalOnly && arg == "--scale") {
+            std::string value;
+            if (!takeValue(value)) {
+                return PrintUsageError(argv[0], "Missing value for --scale. Expected a positive number.");
             }
+            F32 scale = 0.0f;
+            if (!ParsePositiveFloat(value, scale)) {
+                return PrintUsageError(argv[0], jst::fmt::format(
+                    "Invalid value for --scale: '{}'. Expected a positive number.", value));
+            }
+            settings.graphics.scale = scale;
+            runOption = arg;
             continue;
         }
 
-        // Handle Command Options
-
-        switch (command) {
-            case CommandType::Benchmark:
-                if (arg == "--format") {
-                    if (i + 1 >= argc) {
-                        jst::fmt::print(stderr,
-                                        "Missing value for --format. Expected one of: markdown, json, csv.\n\n");
-                        printUsage(argv[0]);
-                        return -1;
-                    }
-
-                    settings.benchmark.format = argv[++i];
-                    continue;
-                }
-                break;
-
-            case CommandType::Remote:
-                if (arg == "--endpoint") {
-                    if (i + 1 < argc) {
-                        settings.remote.brokerUrl = argv[++i];
-                    }
-                    continue;
-                }
-
-                if (arg == "--codec") {
-                    if (i + 1 < argc) {
-                        const std::string codec = argv[++i];
-                        try {
-                            settings.remote.codec = GetRemoteCodecName(StringToRemoteCodec(codec));
-                        } catch (const Result&) {
-                            jst::fmt::print(stderr,
-                                            "Invalid value for --codec: '{}'. Expected one of: {}.\n\n",
-                                            codec,
-                                            RemoteCodecOptionsString());
-                            printUsage(argv[0]);
-                            return -1;
-                        }
-                    } else {
-                        jst::fmt::print(stderr,
-                                        "Missing value for --codec. Expected one of: {}.\n\n",
-                                        RemoteCodecOptionsString());
-                        printUsage(argv[0]);
-                        return -1;
-                    }
-                    continue;
-                }
-
-                if (arg == "--encoder") {
-                    if (i + 1 < argc) {
-                        const std::string enc = argv[++i];
-                        try {
-                            settings.remote.encoder = GetRemoteEncoderName(StringToRemoteEncoder(enc));
-                        } catch (const Result&) {
-                            jst::fmt::print(stderr,
-                                            "Invalid value for --encoder: '{}'. Expected one of: {}.\n\n",
-                                            enc,
-                                            RemoteEncoderOptionsString());
-                            printUsage(argv[0]);
-                            return -1;
-                        }
-                    } else {
-                        jst::fmt::print(stderr,
-                                        "Missing value for --encoder. Expected one of: {}.\n\n",
-                                        RemoteEncoderOptionsString());
-                        printUsage(argv[0]);
-                        return -1;
-                    }
-                    continue;
-                }
-
-                if (arg == "--auto-join") {
-                    settings.remote.autoJoinSessions = true;
-                    continue;
-                }
-                break;
-
-            case CommandType::Run:
-                break;
+        if (!positionalOnly && arg == "--framerate") {
+            std::string value;
+            if (!takeValue(value)) {
+                return PrintUsageError(argv[0], "Missing value for --framerate. Expected a positive integer.");
+            }
+            U64 framerate = 0;
+            if (!ParsePositiveInteger(value, framerate)) {
+                return PrintUsageError(argv[0], jst::fmt::format(
+                    "Invalid value for --framerate: '{}'. Expected a positive integer.", value));
+            }
+            settings.graphics.framerate = framerate;
+            runOption = arg;
+            continue;
         }
 
-        if (arg[0] == '-') {
-            jst::fmt::print(stderr, "Unknown option: '{}'.\n\n", arg);
-            printUsage(argv[0]);
-            return -1;
+        // Handle CyberEther Remote Options
+
+        if (!positionalOnly && arg == "--remote") {
+            if (const int error = rejectInlineValue()) {
+                return error;
+            }
+            remoteEnabled = true;
+            runOption = arg;
+            continue;
+        }
+
+        if (!positionalOnly && arg == "--broker") {
+            std::string value;
+            if (!takeValue(value)) {
+                return PrintUsageError(argv[0], "Missing value for --broker. Expected a URL.");
+            }
+            settings.remote.brokerUrl = value;
+            runOption = arg;
+            remoteSettingOption = arg;
+            continue;
+        }
+
+        if (!positionalOnly && arg == "--codec") {
+            std::string value;
+            if (!takeValue(value)) {
+                return PrintUsageError(argv[0], jst::fmt::format(
+                    "Missing value for --codec. Expected one of: {}.", RemoteCodecOptionsString()));
+            }
+            value = Lowercase(value);
+            if (!IsRemoteCodec(value)) {
+                return PrintUsageError(argv[0], jst::fmt::format(
+                    "Invalid value for --codec: '{}'. Expected one of: {}.",
+                    value,
+                    RemoteCodecOptionsString()));
+            }
+            settings.remote.codec = value;
+            runOption = arg;
+            remoteSettingOption = arg;
+            continue;
+        }
+
+        if (!positionalOnly && arg == "--encoder") {
+            std::string value;
+            if (!takeValue(value)) {
+                return PrintUsageError(argv[0], jst::fmt::format(
+                    "Missing value for --encoder. Expected one of: {}.", RemoteEncoderOptionsString()));
+            }
+            value = Lowercase(value);
+            if (!IsRemoteEncoder(value)) {
+                return PrintUsageError(argv[0], jst::fmt::format(
+                    "Invalid value for --encoder: '{}'. Expected one of: {}.",
+                    value,
+                    RemoteEncoderOptionsString()));
+            }
+            settings.remote.encoder = value;
+            runOption = arg;
+            remoteSettingOption = arg;
+            continue;
+        }
+
+        if (!positionalOnly && arg == "--auto-join-sessions") {
+            if (const int error = rejectInlineValue()) {
+                return error;
+            }
+            settings.remote.autoJoinSessions = true;
+            runOption = arg;
+            remoteSettingOption = arg;
+            continue;
+        }
+
+        // Handle Benchmark Options
+
+        if (!positionalOnly && arg == "--format") {
+            std::string value;
+            if (!takeValue(value)) {
+                return PrintUsageError(argv[0], "Missing value for --format. Expected one of: markdown, json, csv.");
+            }
+            value = Lowercase(value);
+            if (value != "markdown" && value != "json" && value != "csv") {
+                return PrintUsageError(argv[0], jst::fmt::format(
+                    "Invalid value for --format: '{}'. Expected one of: markdown, json, csv.", value));
+            }
+            settings.benchmark.format = value;
+            benchmarkOption = arg;
+            continue;
+        }
+
+        if (!positionalOnly && arg.starts_with("-")) {
+            return PrintUsageError(argv[0], jst::fmt::format("Unknown option: '{}'.", originalArg));
         }
 
         if (command == CommandType::Benchmark) {
-            jst::fmt::print(stderr, "The benchmark command does not accept a flowgraph path: '{}'.\n\n", arg);
-            printUsage(argv[0]);
-            return -1;
+            return PrintUsageError(argv[0], jst::fmt::format(
+                "The benchmark command does not accept a flowgraph: '{}'.", originalArg));
         }
 
-        if (arg[0] != '-') {
-            flowgraphPath = arg;
+        if (!flowgraphPath.empty()) {
+            return PrintUsageError(argv[0], jst::fmt::format(
+                "Only one flowgraph may be provided; received '{}'.", originalArg));
+        }
+
+        flowgraphPath = originalArg;
+    }
+
+    if (command == CommandType::Benchmark && !runOption.empty()) {
+        return PrintUsageError(argv[0], jst::fmt::format(
+            "Option '{}' is not available for the benchmark command.", runOption));
+    }
+
+    if (command == CommandType::Run && !benchmarkOption.empty()) {
+        return PrintUsageError(argv[0], jst::fmt::format(
+            "Option '{}' is only available for the benchmark command.", benchmarkOption));
+    }
+
+    if (!remoteEnabled && !remoteSettingOption.empty()) {
+        return PrintUsageError(argv[0], jst::fmt::format(
+            "Option '{}' requires --remote.", remoteSettingOption));
+    }
+
+    Instance::Remote::Config remoteConfig;
+    if (remoteEnabled) {
+        try {
+            remoteConfig = BuildRemoteConfig(settings);
+        } catch (const Result&) {
+            return PrintUsageError(argv[0], "The configured CyberEther Remote codec or encoder is invalid.");
         }
     }
 
@@ -352,16 +599,6 @@ int Run(int argc, char* argv[], PluginCreateFn pluginCreate, PluginDestroyFn plu
     //
 
     if (command == CommandType::Benchmark) {
-        if (settings.benchmark.format != "markdown" &&
-            settings.benchmark.format != "json" &&
-            settings.benchmark.format != "csv") {
-            jst::fmt::print(stderr,
-                            "Invalid value for --format: '{}'. Expected one of: markdown, json, csv.\n\n",
-                            settings.benchmark.format);
-            printUsage(argv[0]);
-            return -1;
-        }
-
         Benchmark::Run(settings.benchmark.format);
         return 0;
     }
@@ -370,17 +607,7 @@ int Run(int argc, char* argv[], PluginCreateFn pluginCreate, PluginDestroyFn plu
     // Interface Logic
     //
 
-    if (command == CommandType::Run || command == CommandType::Remote) {
-        Instance::Remote::Config remoteConfig;
-        if (command == CommandType::Remote) {
-            try {
-                remoteConfig = BuildRemoteConfig(settings);
-            } catch (const Result&) {
-                printUsage(argv[0]);
-                return -1;
-            }
-        }
-
+    if (command == CommandType::Run) {
         const Instance::Config config = BuildInstanceConfig(settings);
 
         if (Settings::Set(settings, false) != Result::SUCCESS) {
@@ -422,7 +649,7 @@ int Run(int argc, char* argv[], PluginCreateFn pluginCreate, PluginDestroyFn plu
             return -1;
         }
 
-        if (command == CommandType::Remote) {
+        if (remoteEnabled) {
             if (instance->remote()->create(remoteConfig) != Result::SUCCESS) {
                 (void)instance->stop();
                 if (pluginDestroy) {
@@ -483,7 +710,7 @@ int Run(int argc, char* argv[], PluginCreateFn pluginCreate, PluginDestroyFn plu
             }
         });
 
-        if (command == CommandType::Remote && instance->remote()) {
+        if (remoteEnabled && instance->remote()) {
             supervisor = std::make_unique<Instance::Remote::Supervisor>(
                 instance->remote().get(),
                 remoteConfig.autoJoinSessions
@@ -503,7 +730,7 @@ int Run(int argc, char* argv[], PluginCreateFn pluginCreate, PluginDestroyFn plu
             supervisor->stop();
         }
 
-        if (command == CommandType::Remote && instance->remote()->started()) {
+        if (remoteEnabled && instance->remote()->started()) {
             (void)instance->remote()->destroy();
         }
 

--- a/src/run_native.cc
+++ b/src/run_native.cc
@@ -24,6 +24,7 @@ namespace {
 Instance::Config BuildInstanceConfig(const Settings& settings) {
     Instance::Config config = {
         .device = settings.graphics.device,
+        .deviceId = settings.graphics.deviceId,
         .compositor = CompositorType::DEFAULT,
         .headless = settings.graphics.headless,
         .size = {settings.graphics.size.width, settings.graphics.size.height},
@@ -131,6 +132,22 @@ bool ParsePositiveInteger(const std::string& value, U64& result) {
     return true;
 }
 
+bool ParseDeviceId(const std::string& value, U64& result) {
+    if (value.empty() || !std::all_of(value.begin(), value.end(), [](unsigned char c) {
+        return std::isdigit(c);
+    })) {
+        return false;
+    }
+
+    try {
+        size_t parsed = 0;
+        result = std::stoull(value, &parsed);
+        return parsed == value.size();
+    } catch (const std::exception&) {
+        return false;
+    }
+}
+
 bool ParsePositiveFloat(const std::string& value, F32& result) {
     try {
         size_t parsed = 0;
@@ -208,7 +225,9 @@ static void printUsage(const char* program,
     jst::fmt::print("Global Options:\n");
     jst::fmt::print("  -h, --help                   Show this help\n");
     jst::fmt::print("  -v, -vv                      Set debug or trace log level\n");
-    jst::fmt::print("  -V, --version                Show version\n\n");
+    jst::fmt::print("  -V, --version                Show version\n");
+    jst::fmt::print("  --device-index <index>       Vulkan and CUDA device index (current: {})\n\n",
+                    settings.graphics.deviceId);
 
     if (!command.has_value() || *command == CommandType::Run) {
         jst::fmt::print("Graphics Options:\n");
@@ -405,6 +424,20 @@ int Run(int argc, char* argv[], PluginCreateFn pluginCreate, PluginDestroyFn plu
             }
             settings.graphics.device = StringToDevice(value);
             runOption = arg;
+            continue;
+        }
+
+        if (!positionalOnly && arg == "--device-index") {
+            std::string value;
+            if (!takeValue(value)) {
+                return PrintUsageError(argv[0], "Missing value for --device-index. Expected a non-negative integer.");
+            }
+            U64 deviceId = 0;
+            if (!ParseDeviceId(value, deviceId)) {
+                return PrintUsageError(argv[0], jst::fmt::format(
+                    "Invalid value for --device-index: '{}'. Expected a non-negative integer.", value));
+            }
+            settings.graphics.deviceId = deviceId;
             continue;
         }
 
@@ -611,11 +644,17 @@ int Run(int argc, char* argv[], PluginCreateFn pluginCreate, PluginDestroyFn plu
 
     JST_INFO("[CYBERETHER] Running native app.");
 
-#ifdef JETSTREAM_BACKEND_CPU_AVAILABLE
     const auto backendConfig = Backend::Config {
+        .deviceId = settings.graphics.deviceId,
         .headless = settings.graphics.headless,
         .pythonRuntimePath = settings.runtime.python.path,
     };
+#ifdef JETSTREAM_BACKEND_CUDA_AVAILABLE
+    if (Backend::Configure<DeviceType::CUDA>(backendConfig) != Result::SUCCESS) {
+        return -1;
+    }
+#endif
+#ifdef JETSTREAM_BACKEND_CPU_AVAILABLE
     if (Backend::Initialize<DeviceType::CPU>(backendConfig) != Result::SUCCESS) {
         return -1;
     }

--- a/src/runtime/native/cuda/impl.cc
+++ b/src/runtime/native/cuda/impl.cc
@@ -1,5 +1,6 @@
 #include <jetstream/detail/runtime_impl.hh>
 #include <jetstream/runtime_context_native_cuda.hh>
+#include <jetstream/backend/base.hh>
 #include <jetstream/backend/devices/cuda/helpers.hh>
 #include <jetstream/scheduler_context.hh>
 #include <jetstream/module_context.hh>
@@ -32,6 +33,8 @@ struct NativeCudaRuntime : public Runtime::Impl {
 };
 
 Result NativeCudaRuntime::create(const Runtime::Modules& modules) {
+    JST_CHECK(Backend::State<DeviceType::CUDA>()->activate());
+
     // Create stream.
 
     JST_CUDA_CHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), [&]{
@@ -115,6 +118,8 @@ Result NativeCudaRuntime::create(const Runtime::Modules& modules) {
 }
 
 Result NativeCudaRuntime::destroy() {
+    JST_CHECK(Backend::State<DeviceType::CUDA>()->activate());
+
     // Deinitalize modules.
 
     for (auto& [name, module] : modulesMap) {
@@ -156,6 +161,8 @@ Result NativeCudaRuntime::destroy() {
 Result NativeCudaRuntime::compute(const std::vector<std::string>& modules,
                                   std::unordered_set<std::string>& skippedModules,
                                   std::unordered_set<std::string>& failedModules) {
+    JST_CHECK(Backend::State<DeviceType::CUDA>()->activate());
+
     const auto& targetNames = modules.empty() ? moduleNames : modules;
     std::vector<std::string> executedModules;
 

--- a/src/superluminal/base.cc
+++ b/src/superluminal/base.cc
@@ -109,6 +109,7 @@ Result Superluminal::initialize(const InstanceConfig& config) {
     // Initialize the instance.
 
     Instance::Config instanceConfig = {
+        .deviceId = impl->config.deviceId,
         .size = impl->config.interfaceSize,
         .scale = impl->config.interfaceScale,
     };

--- a/tests/cli/main.cc
+++ b/tests/cli/main.cc
@@ -175,6 +175,9 @@ TEST_CASE("CLI accepts normalized and inline values", "[cli]") {
     Expect("run values",
            {"--renderer=METAL",
             "--device-index=7",
+            "--plugin=first.cep",
+            "--plugin",
+            "second.cep",
             "--size=640X480",
             "--scale=2",
             "--framerate=30",
@@ -194,7 +197,7 @@ TEST_CASE("CLI accepts normalized and inline values", "[cli]") {
             "Streaming codec (current: h264)",
             "Streaming encoder (current: auto)"});
     Expect("benchmark values",
-           {"--format=JSON", "benchmark", "fft", "--help"},
+           {"--format=JSON", "benchmark", "fft", "--plugin=benchmark.cep", "--help"},
            0,
            {"benchmark [options] [block]", "Output format (current: json)"});
     Expect("zero device index",
@@ -206,6 +209,7 @@ TEST_CASE("CLI accepts normalized and inline values", "[cli]") {
 TEST_CASE("CLI rejects invalid syntax and command conflicts", "[cli]") {
     Expect("malformed delimiter value", {"--=value", "--help"}, 2, {}, {"Unknown option: '--=value'."});
     Expect("empty malformed delimiter", {"--=", "--help"}, 2, {}, {"Unknown option: '--='."});
+    Expect("missing plugin path", {"--plugin"}, 2, {}, {"Missing value for --plugin"});
     Expect("dash-prefixed flowgraph", {"--", "--flowgraph.yml", "second.yml"}, 2, {}, {"Only one flowgraph"});
     Expect("benchmark delimiter", {"benchmark", "--", "--block", "second"}, 2, {}, {"Only one benchmark block"});
     Expect("multiple flowgraphs", {"one.yml", "two.yml"}, 2, {}, {"Only one flowgraph"});

--- a/tests/cli/main.cc
+++ b/tests/cli/main.cc
@@ -1,0 +1,252 @@
+#include <catch2/catch_session.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <initializer_list>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#if defined(_WIN32)
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+#include "jetstream/run.hh"
+
+namespace {
+
+#if defined(_WIN32)
+int FileDescriptor(FILE* stream) { return _fileno(stream); }
+int Duplicate(int descriptor) { return _dup(descriptor); }
+int Redirect(int source, int destination) { return _dup2(source, destination); }
+void Close(int descriptor) { (void)_close(descriptor); }
+#else
+int FileDescriptor(FILE* stream) { return fileno(stream); }
+int Duplicate(int descriptor) { return dup(descriptor); }
+int Redirect(int source, int destination) { return dup2(source, destination); }
+void Close(int descriptor) { (void)close(descriptor); }
+#endif
+
+class StreamCapture {
+ public:
+    explicit StreamCapture(FILE* stream) : stream_(stream), descriptor_(FileDescriptor(stream)) {
+        file_ = std::tmpfile();
+        savedDescriptor_ = Duplicate(descriptor_);
+        REQUIRE(file_ != nullptr);
+        REQUIRE(savedDescriptor_ >= 0);
+        std::fflush(stream_);
+        REQUIRE(Redirect(FileDescriptor(file_), descriptor_) >= 0);
+    }
+
+    ~StreamCapture() {
+        if (!finished_) {
+            (void)finish();
+        }
+    }
+
+    std::string finish() {
+        std::fflush(stream_);
+        std::rewind(file_);
+
+        std::string output;
+        char buffer[4096];
+        while (const size_t size = std::fread(buffer, 1, sizeof(buffer), file_)) {
+            output.append(buffer, size);
+        }
+
+        (void)Redirect(savedDescriptor_, descriptor_);
+        Close(savedDescriptor_);
+        std::fclose(file_);
+        finished_ = true;
+        return output;
+    }
+
+ private:
+    FILE* stream_;
+    FILE* file_ = nullptr;
+    int descriptor_;
+    int savedDescriptor_ = -1;
+    bool finished_ = false;
+};
+
+struct InvocationResult {
+    int code;
+    std::string out;
+    std::string err;
+};
+
+InvocationResult Invoke(std::initializer_list<const char*> arguments) {
+    std::vector<std::string> values = {"cyberether"};
+    for (const char* argument : arguments) {
+        values.emplace_back(argument);
+    }
+
+    std::vector<char*> argv;
+    argv.reserve(values.size());
+    for (auto& value : values) {
+        argv.push_back(value.data());
+    }
+
+    StreamCapture out(stdout);
+    StreamCapture err(stderr);
+    const int code = Jetstream::Run(static_cast<int>(argv.size()), argv.data());
+    return {code, out.finish(), err.finish()};
+}
+
+void Expect(const char* label,
+            std::initializer_list<const char*> arguments,
+            int code,
+            std::initializer_list<const char*> out = {},
+            std::initializer_list<const char*> err = {},
+            std::initializer_list<const char*> absentOut = {},
+            std::initializer_list<const char*> absentErr = {}) {
+    INFO("CLI case: " << label);
+    const InvocationResult result = Invoke(arguments);
+    CHECK(result.code == code);
+    for (const char* value : out) {
+        CHECK(result.out.find(value) != std::string::npos);
+    }
+    for (const char* value : err) {
+        CHECK(result.err.find(value) != std::string::npos);
+    }
+    for (const char* value : absentOut) {
+        CHECK(result.out.find(value) == std::string::npos);
+    }
+    for (const char* value : absentErr) {
+        CHECK(result.err.find(value) == std::string::npos);
+    }
+}
+
+void ConfigureSettingsSandbox() {
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto root = std::filesystem::temp_directory_path() /
+                      ("cyberether-cli-" + std::to_string(nonce));
+    std::filesystem::create_directories(root);
+
+#if defined(_WIN32)
+    if (_wputenv_s(L"APPDATA", root.wstring().c_str()) != 0) {
+        throw std::runtime_error("failed to configure CLI test settings sandbox");
+    }
+#elif defined(__APPLE__)
+    if (setenv("CFFIXED_USER_HOME", root.string().c_str(), 1) != 0) {
+        throw std::runtime_error("failed to configure CLI test settings sandbox");
+    }
+#else
+    if (setenv("HOME", root.string().c_str(), 1) != 0 ||
+        setenv("XDG_CONFIG_HOME", root.string().c_str(), 1) != 0) {
+        throw std::runtime_error("failed to configure CLI test settings sandbox");
+    }
+#endif
+}
+
+}  // namespace
+
+TEST_CASE("CLI displays contextual help and version", "[cli]") {
+    Expect("global help",
+           {"--help"},
+           0,
+           {"Usage:\n", "Commands:\n", "Graphics Options:\n", "Benchmark Options:\n"},
+           {},
+           {},
+           {"Error:"});
+    Expect("run help",
+           {"run", "--help"},
+           0,
+           {"run [options] [flowgraph]", "Graphics Options:\n"},
+           {},
+           {"Benchmark Options:\n"});
+    Expect("benchmark help",
+           {"benchmark", "--help"},
+           0,
+           {"benchmark [options]", "Benchmark Options:\n"},
+           {},
+           {"Graphics Options:\n"});
+    Expect("command ordering", {"-v", "run", "--help"}, 0, {"run [options] [flowgraph]"});
+    Expect("version", {"--version"}, 0, {"CyberEther v"}, {}, {}, {"Error:"});
+}
+
+TEST_CASE("CLI accepts normalized and inline values", "[cli]") {
+    Expect("run values",
+           {"--renderer=METAL",
+            "--size=640X480",
+            "--scale=2",
+            "--framerate=30",
+            "--remote",
+            "--broker=https://example.com",
+            "--codec=H264",
+            "--encoder=AUTO",
+            "--auto-join-sessions",
+            "--help"},
+           0,
+           {"Preferred graphics backend (current: metal)",
+            "Viewport size (current: 640x480)",
+            "Interface scale factor (current: 2.0)",
+            "Target frame rate (current: 30)",
+            "Broker URL (current: https://example.com)",
+            "Streaming codec (current: h264)",
+            "Streaming encoder (current: auto)"});
+    Expect("benchmark values",
+           {"--format=JSON", "benchmark", "--help"},
+           0,
+           {"Output format (current: json)"});
+}
+
+TEST_CASE("CLI rejects invalid syntax and command conflicts", "[cli]") {
+    Expect("malformed delimiter value", {"--=value", "--help"}, 2, {}, {"Unknown option: '--=value'."});
+    Expect("empty malformed delimiter", {"--=", "--help"}, 2, {}, {"Unknown option: '--='."});
+    Expect("dash-prefixed flowgraph", {"--", "--flowgraph.yml", "second.yml"}, 2, {}, {"Only one flowgraph"});
+    Expect("benchmark delimiter", {"benchmark", "--", "--flowgraph.yml"}, 2, {}, {"does not accept a flowgraph"});
+    Expect("multiple flowgraphs", {"one.yml", "two.yml"}, 2, {}, {"Only one flowgraph"});
+    Expect("benchmark flowgraph", {"benchmark", "flowgraph.yml"}, 2, {}, {"does not accept a flowgraph"});
+    Expect("run option with benchmark", {"benchmark", "--headless"}, 2, {}, {"not available for the benchmark command"});
+    Expect("benchmark option with run", {"run", "--format", "json"}, 2, {}, {"only available for the benchmark command"});
+}
+
+TEST_CASE("CLI enforces remote option dependencies", "[cli]") {
+    Expect("broker", {"--broker", "https://example.com"}, 2, {}, {"requires --remote"});
+    Expect("codec", {"--codec", "h264"}, 2, {}, {"requires --remote"});
+    Expect("encoder", {"--encoder", "auto"}, 2, {}, {"requires --remote"});
+    Expect("auto join", {"--auto-join-sessions"}, 2, {}, {"requires --remote"});
+    Expect("headless value", {"--headless=true"}, 2, {}, {"does not accept a value"});
+    Expect("remote value", {"--remote=true"}, 2, {}, {"does not accept a value"});
+}
+
+TEST_CASE("CLI validates numeric values", "[cli]") {
+    const std::vector<std::pair<const char*, const char*>> errors = {
+        {"--size", "Missing value for --size"},
+        {"--size=0x480", "Invalid value for --size"},
+        {"--size=640x0", "Invalid value for --size"},
+        {"--size=640x480x2", "Invalid value for --size"},
+        {"--size=2147483648x480", "Invalid value for --size"},
+        {"--size=18446744073709551616x480", "Invalid value for --size"},
+        {"--scale=0", "Invalid value for --scale"},
+        {"--scale=-1", "Invalid value for --scale"},
+        {"--scale=nan", "Invalid value for --scale"},
+        {"--scale=inf", "Invalid value for --scale"},
+        {"--framerate=0", "Invalid value for --framerate"},
+        {"--framerate=-1", "Invalid value for --framerate"},
+        {"--framerate=18446744073709551616", "Invalid value for --framerate"},
+    };
+    for (const auto& [argument, message] : errors) {
+        Expect(argument, {argument}, 2, {}, {message});
+    }
+}
+
+TEST_CASE("CLI rejects removed commands and options", "[cli]") {
+    Expect("remote command", {"remote"}, 2, {}, {"Unknown command: 'remote'."});
+    Expect("device option", {"--device"}, 2, {}, {"Unknown option: '--device'."});
+    Expect("device ID option", {"--device-id"}, 2, {}, {"Unknown option: '--device-id'."});
+    Expect("endpoint option", {"--endpoint"}, 2, {}, {"Unknown option: '--endpoint'."});
+    Expect("auto join option", {"--auto-join"}, 2, {}, {"Unknown option: '--auto-join'."});
+}
+
+int main(int argc, char* argv[]) {
+    ConfigureSettingsSandbox();
+    return Catch::Session().run(argc, argv);
+}

--- a/tests/cli/main.cc
+++ b/tests/cli/main.cc
@@ -174,6 +174,7 @@ TEST_CASE("CLI displays contextual help and version", "[cli]") {
 TEST_CASE("CLI accepts normalized and inline values", "[cli]") {
     Expect("run values",
            {"--renderer=METAL",
+            "--device-index=7",
             "--size=640X480",
             "--scale=2",
             "--framerate=30",
@@ -185,6 +186,7 @@ TEST_CASE("CLI accepts normalized and inline values", "[cli]") {
             "--help"},
            0,
            {"Preferred graphics backend (current: metal)",
+            "Vulkan and CUDA device index (current: 7)",
             "Viewport size (current: 640x480)",
             "Interface scale factor (current: 2.0)",
             "Target frame rate (current: 30)",
@@ -195,6 +197,10 @@ TEST_CASE("CLI accepts normalized and inline values", "[cli]") {
            {"--format=JSON", "benchmark", "fft", "--help"},
            0,
            {"benchmark [options] [block]", "Output format (current: json)"});
+    Expect("zero device index",
+           {"--device-index", "0", "--help"},
+           0,
+           {"Vulkan and CUDA device index (current: 0)"});
 }
 
 TEST_CASE("CLI rejects invalid syntax and command conflicts", "[cli]") {
@@ -205,6 +211,10 @@ TEST_CASE("CLI rejects invalid syntax and command conflicts", "[cli]") {
     Expect("multiple flowgraphs", {"one.yml", "two.yml"}, 2, {}, {"Only one flowgraph"});
     Expect("multiple benchmark blocks", {"benchmark", "fft", "am"}, 2, {}, {"Only one benchmark block"});
     Expect("run option with benchmark", {"benchmark", "--headless"}, 2, {}, {"not available for the benchmark command"});
+    Expect("device index with benchmark",
+           {"benchmark", "--device-index", "7", "--help"},
+           0,
+           {"Vulkan and CUDA device index (current: 7)"});
     Expect("benchmark option with run", {"run", "--format", "json"}, 2, {}, {"only available for the benchmark command"});
 }
 
@@ -232,6 +242,10 @@ TEST_CASE("CLI validates numeric values", "[cli]") {
         {"--framerate=0", "Invalid value for --framerate"},
         {"--framerate=-1", "Invalid value for --framerate"},
         {"--framerate=18446744073709551616", "Invalid value for --framerate"},
+        {"--device-index", "Missing value for --device-index"},
+        {"--device-index=-1", "Invalid value for --device-index"},
+        {"--device-index=invalid", "Invalid value for --device-index"},
+        {"--device-index=18446744073709551616", "Invalid value for --device-index"},
     };
     for (const auto& [argument, message] : errors) {
         Expect(argument, {argument}, 2, {}, {message});

--- a/tests/cli/main.cc
+++ b/tests/cli/main.cc
@@ -164,7 +164,7 @@ TEST_CASE("CLI displays contextual help and version", "[cli]") {
     Expect("benchmark help",
            {"benchmark", "--help"},
            0,
-           {"benchmark [options]", "Benchmark Options:\n"},
+           {"benchmark [options] [block]", "Benchmark Options:\n"},
            {},
            {"Graphics Options:\n"});
     Expect("command ordering", {"-v", "run", "--help"}, 0, {"run [options] [flowgraph]"});
@@ -192,18 +192,18 @@ TEST_CASE("CLI accepts normalized and inline values", "[cli]") {
             "Streaming codec (current: h264)",
             "Streaming encoder (current: auto)"});
     Expect("benchmark values",
-           {"--format=JSON", "benchmark", "--help"},
+           {"--format=JSON", "benchmark", "fft", "--help"},
            0,
-           {"Output format (current: json)"});
+           {"benchmark [options] [block]", "Output format (current: json)"});
 }
 
 TEST_CASE("CLI rejects invalid syntax and command conflicts", "[cli]") {
     Expect("malformed delimiter value", {"--=value", "--help"}, 2, {}, {"Unknown option: '--=value'."});
     Expect("empty malformed delimiter", {"--=", "--help"}, 2, {}, {"Unknown option: '--='."});
     Expect("dash-prefixed flowgraph", {"--", "--flowgraph.yml", "second.yml"}, 2, {}, {"Only one flowgraph"});
-    Expect("benchmark delimiter", {"benchmark", "--", "--flowgraph.yml"}, 2, {}, {"does not accept a flowgraph"});
+    Expect("benchmark delimiter", {"benchmark", "--", "--block", "second"}, 2, {}, {"Only one benchmark block"});
     Expect("multiple flowgraphs", {"one.yml", "two.yml"}, 2, {}, {"Only one flowgraph"});
-    Expect("benchmark flowgraph", {"benchmark", "flowgraph.yml"}, 2, {}, {"does not accept a flowgraph"});
+    Expect("multiple benchmark blocks", {"benchmark", "fft", "am"}, 2, {}, {"Only one benchmark block"});
     Expect("run option with benchmark", {"benchmark", "--headless"}, 2, {}, {"not available for the benchmark command"});
     Expect("benchmark option with run", {"run", "--format", "json"}, 2, {}, {"only available for the benchmark command"});
 }

--- a/tests/cli/meson.build
+++ b/tests/cli/meson.build
@@ -1,0 +1,9 @@
+test(
+    'cli',
+    executable(
+        'jetstream-cli-tests',
+        'main.cc',
+        dependencies: [libjetstream_dep, catch2_dep],
+    ),
+    timeout: 60,
+)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -7,4 +7,8 @@ if catch2_dep.found()
     subdir('flowgraph')
 endif
 
+if catch2_dep.found() and not jst_is_ios and not jst_is_android
+    subdir('cli')
+endif
+
 subdir('components')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -7,7 +7,11 @@ if catch2_dep.found()
     subdir('flowgraph')
 endif
 
-if catch2_dep.found() and not jst_is_ios and not jst_is_android
+# TODO: Re-enable after CLI output capture supports separate Windows static CRTs.
+if catch2_dep.found() and \
+   not jst_is_ios and \
+   not jst_is_android and \
+   not jst_is_windows
     subdir('cli')
 endif
 

--- a/tests/settings/settings.cc
+++ b/tests/settings/settings.cc
@@ -263,6 +263,31 @@ TEST_CASE("Settings can update memory without persisting", "[settings]") {
     REQUIRE(restored.developer.timingEnabled);
 }
 
+TEST_CASE("Transient settings can be restored before a retained update", "[settings]") {
+    SettingsSandbox sandbox("transient-restore");
+
+    Settings retained;
+    retained.graphics.scale = 1.25f;
+    retained.remote.brokerUrl = "https://retained.example.com";
+    REQUIRE(Settings::Set(retained) == Result::SUCCESS);
+
+    Settings runtime = retained;
+    runtime.graphics.scale = 3.0f;
+    runtime.remote.brokerUrl = "https://runtime.example.com";
+    REQUIRE(Settings::Set(runtime, false) == Result::SUCCESS);
+    REQUIRE(Settings::Set(retained, false) == Result::SUCCESS);
+
+    Settings updated;
+    REQUIRE(Settings::Get(updated) == Result::SUCCESS);
+    updated.interface.infoPanelEnabled = false;
+    REQUIRE(Settings::Set(updated) == Result::SUCCESS);
+
+    const auto yaml = ReadFile(sandbox.path);
+    REQUIRE(yaml.find("https://retained.example.com") != std::string::npos);
+    REQUIRE(yaml.find("https://runtime.example.com") == std::string::npos);
+    REQUIRE(yaml.find("scale: 1.25") != std::string::npos);
+}
+
 TEST_CASE("Python runtime validation treats framework binaries as libraries", "[settings][runtime][python]") {
     TempPathRoot sandbox("fake-python-framework-runtime");
     const auto fakeLibraryPath = sandbox.root / "Python.framework" / "Versions" / "3.14" / "Python";

--- a/tests/settings/settings.cc
+++ b/tests/settings/settings.cc
@@ -174,6 +174,7 @@ TEST_CASE("Settings returns defaults when file is missing", "[settings]") {
 
     REQUIRE(settings.graphics.size.width == 1920);
     REQUIRE(settings.graphics.size.height == 1080);
+    REQUIRE(settings.graphics.deviceId == 0);
     REQUIRE(settings.interface.themeKey == "Dark");
     REQUIRE(settings.interface.infoPanelEnabled);
     REQUIRE(settings.remote.brokerUrl == "https://cyberether.org");
@@ -186,6 +187,7 @@ TEST_CASE("Settings persists root YAML", "[settings]") {
 
     Settings settings;
     settings.benchmark.format = "json";
+    settings.graphics.deviceId = 2;
     settings.graphics.headless = true;
     settings.graphics.size.width = 1280;
     settings.graphics.size.height = 720;
@@ -202,6 +204,7 @@ TEST_CASE("Settings persists root YAML", "[settings]") {
     REQUIRE(yaml.find("format") == std::string::npos);
     REQUIRE(yaml.find("graphics:") != std::string::npos);
     REQUIRE(yaml.find("headless") == std::string::npos);
+    REQUIRE(yaml.find("deviceId") == std::string::npos);
     REQUIRE(yaml.find("interface:") != std::string::npos);
     REQUIRE(yaml.find("remote:") != std::string::npos);
     REQUIRE(yaml.find("registry:") != std::string::npos);


### PR DESCRIPTION
- feat(benchmark): add block filtering to CLI benchmarks
- fix(cli): keep command-line overrides transient
- feat(backend): wire Vulkan and CUDA device-index selection
- fix(cuda): bind contexts across runtime threads
- feat(cli): add temporary plugin loading