### PR TITLE
fix: enable automatic kernel driver detaching for librtlsdr

### DIFF
--- a/subprojects/packagefiles/librtlsdr/meson.build
+++ b/subprojects/packagefiles/librtlsdr/meson.build
@@ -2,7 +2,8 @@ project('librtlsdr', 'c', version: '0.7.0', default_options: ['cpp_std=c++11', '
 
 private_cpp_args = []
 interface_cpp_args = []
-private_cpp_args += []
+# Detach the DVB-T kernel driver instead of failing with LIBUSB_ERROR_BUSY.
+private_cpp_args += ['-DDETACH_KERNEL_DRIVER=1']
 interface_cpp_args += []
 
 if target_machine.system().startswith('windows')


### PR DESCRIPTION
On my linux system the rtl-sdr device was already claimed by the kernels DVB-T module (`dvb_usb_rtl28xxu`), and the bundled librtlsdr from the app image was built without `DETACH_KERNEL_DRIVER`, so it fails to open the device:

```
Kernel driver is active, or device is claimed by second instance of librtlsdr.
In the first case, please either detach or blacklist the kernel module
(dvb_usb_rtl28xxu), or enable automatic detaching at compile time.

usb_claim_interface error -6

Kernel driver is active, or device is claimed by second instance of librtlsdr.
In the first case, please either detach or blacklist the kernel module
(dvb_usb_rtl28xxu), or enable automatic detaching at compile time.

usb_claim_interface error -6

Kernel driver is active, or device is claimed by second instance of librtlsdr.
In the first case, please either detach or blacklist the kernel module
(dvb_usb_rtl28xxu), or enable automatic detaching at compile time.

usb_claim_interface error -6

Kernel driver is active, or device is claimed by second instance of librtlsdr.
In the first case, please either detach or blacklist the kernel module
(dvb_usb_rtl28xxu), or enable automatic detaching at compile time.

usb_claim_interface error -6
[INFO] Opening Generic RTL2832U OEM :: 00000001...

Kernel driver is active, or device is claimed by second instance of librtlsdr.
In the first case, please either detach or blacklist the kernel module
(dvb_usb_rtl28xxu), or enable automatic detaching at compile time.

usb_claim_interface error -6
JETSTREAM [ERROR] | [MODULE_SOAPY] Failed to open device: Unable to open RTL-SDR device
```

With this change librtlsdr detaches the kernel driver and the device can be successfully opened in CyberEther.