### PR TITLE
fix: MSVC string literal limit in Python bridge header generation

### DIFF
--- a/src/runtime/python/bridge/prelude/meson.py
+++ b/src/runtime/python/bridge/prelude/meson.py
@@ -19,6 +19,29 @@ def read_component(input_path):
         return source.read()
 
 
+# MSVC (C2026) rejects a single string literal larger than 16380 bytes. Split the
+# content into smaller chunks emitted as adjacent raw string literals, which the
+# compiler concatenates back together. Kept well under the limit for UTF-8 slack.
+CHUNK_SIZE = 8000
+
+
+def chunk_bytes(content):
+    # Split on character boundaries with a byte budget so each emitted chunk is
+    # valid UTF-8 on its own; concatenating them reproduces the original exactly.
+    chunk = []
+    size = 0
+    for ch in content:
+        ch_len = len(ch.encode("utf-8"))
+        if size + ch_len > CHUNK_SIZE and chunk:
+            yield "".join(chunk)
+            chunk = []
+            size = 0
+        chunk.append(ch)
+        size += ch_len
+    if chunk:
+        yield "".join(chunk)
+
+
 def generate_header(input_paths, output_path):
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
 
@@ -31,11 +54,14 @@ def generate_header(input_paths, output_path):
     content = "\n\n".join(components)
     delimiter = raw_string_delimiter(content)
 
+    chunks = list(chunk_bytes(content)) or [""]
+
     with open(output_path, "w", encoding="utf-8") as output:
         output.write("#pragma once\n\n")
         output.write("namespace Jetstream {\n\n")
-        output.write("inline constexpr const char* kPythonBridge = ")
-        output.write(f'R"{delimiter}({content}){delimiter}"')
+        output.write("inline constexpr const char* kPythonBridge =\n")
+        for chunk in chunks:
+            output.write(f'R"{delimiter}({chunk}){delimiter}"\n')
         output.write(";\n\n")
         output.write("}  // namespace Jetstream\n")
 


### PR DESCRIPTION
MSVC (C2026) rejects a single string literal larger than 16380 bytes. The generated kPythonBridge header exceeds this (~19.5KB from the combined prelude/*.py sources), causing a build failure on Windows/MSVC.

This splits the embedded content into adjacent raw string literals (8000-byte chunks), which the compiler concatenates back together ... a well-known workaround for this MSVC limitation.
