### PR TITLE
feat(superluminal): add GlobalInterface for controls above the mosaic

### DIFF
--- a/examples/superluminal/global_interface/global_interface.cc
+++ b/examples/superluminal/global_interface/global_interface.cc
@@ -1,0 +1,77 @@
+#include <jetstream/superluminal.hh>
+#include <cmath>
+#include <cstdlib>
+
+using namespace Jetstream;
+
+static constexpr float kPi = JST_PI;
+
+void GenerateTestSignal(Tensor& data, float frequency, float amplitude, float noise_level) {
+    const float sample_rate = 44100.0f;
+
+    for (U64 j = 0; j < data.shape(1); j++) {
+        float t = j / sample_rate;
+
+        float signal = amplitude * std::cos(2.0f * kPi * frequency * t);
+        float noise = (std::rand() / float(RAND_MAX) - 0.5f) * noise_level;
+
+        data.at<CF32>(0, j) = CF32(signal + noise, 0.0f);
+    }
+}
+
+/**
+ * Jetstream Superluminal Global Interface Demo
+ *
+ * Unlike Interface and Box, which occupy a mosaic cell, GlobalInterface draws
+ * above the mosaic. The space it takes is reserved, so the plots below shrink
+ * to fit underneath it instead of being covered.
+ */
+static Result App() {
+    Tensor data(DeviceType::CPU, TypeToDataType<CF32>(), {1, 8192});
+
+    float frequency = 1000.0f;
+    float amplitude = 1.0f;
+    float noise_level = 0.1f;
+
+    GenerateTestSignal(data, frequency, amplitude, noise_level);
+
+    // Control bar spanning the top of the window, outside of the mosaic.
+    JST_CHECK(Superluminal::GlobalInterface([&]{
+        Superluminal::Text("Signal Parameters");
+        Superluminal::Slider("Frequency (Hz)", 100.0f, 5000.0f, frequency);
+        Superluminal::Slider("Amplitude", 0.1f, 2.0f, amplitude);
+        Superluminal::Slider("Noise Level", 0.0f, 0.5f, noise_level);
+    }));
+
+    // Both cells resize to fit below the control bar.
+    JST_CHECK(Superluminal::Plot("Time", {{1}, {0}}, {
+        .buffer = data,
+        .type = Superluminal::Type::Line,
+        .source = Superluminal::Domain::Time,
+        .display = Superluminal::Domain::Time,
+        .options = {},
+    }));
+
+    JST_CHECK(Superluminal::Plot("Frequency", {{0}, {1}}, {
+        .buffer = data,
+        .type = Superluminal::Type::Line,
+        .source = Superluminal::Domain::Time,
+        .display = Superluminal::Domain::Frequency,
+        .options = {},
+    }));
+
+    JST_CHECK(Superluminal::RealtimeLoop([&](const bool& running){
+        while (running) {
+            GenerateTestSignal(data, frequency, amplitude, noise_level);
+
+            Superluminal::Update();
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }));
+
+    return Result::SUCCESS;
+}
+
+int main() {
+    return App() == Result::SUCCESS ? 0 : 1;
+}

--- a/examples/superluminal/global_interface/global_interface.cc
+++ b/examples/superluminal/global_interface/global_interface.cc
@@ -1,4 +1,5 @@
 #include <jetstream/superluminal.hh>
+#include <atomic>
 #include <cmath>
 #include <cstdlib>
 
@@ -29,18 +30,26 @@ void GenerateTestSignal(Tensor& data, float frequency, float amplitude, float no
 static Result App() {
     Tensor data(DeviceType::CPU, TypeToDataType<CF32>(), {1, 8192});
 
-    float frequency = 1000.0f;
-    float amplitude = 1.0f;
-    float noise_level = 0.1f;
+    std::atomic<float> frequency = 1000.0f;
+    std::atomic<float> amplitude = 1.0f;
+    std::atomic<float> noise_level = 0.1f;
 
-    GenerateTestSignal(data, frequency, amplitude, noise_level);
+    GenerateTestSignal(data, frequency.load(), amplitude.load(), noise_level.load());
 
     // Control bar spanning the top of the window, outside of the mosaic.
     JST_CHECK(Superluminal::GlobalInterface([&]{
+        float current_frequency = frequency.load(std::memory_order_relaxed);
+        float current_amplitude = amplitude.load(std::memory_order_relaxed);
+        float current_noise_level = noise_level.load(std::memory_order_relaxed);
+
         Superluminal::Text("Signal Parameters");
-        Superluminal::Slider("Frequency (Hz)", 100.0f, 5000.0f, frequency);
-        Superluminal::Slider("Amplitude", 0.1f, 2.0f, amplitude);
-        Superluminal::Slider("Noise Level", 0.0f, 0.5f, noise_level);
+        Superluminal::Slider("Frequency (Hz)", 100.0f, 5000.0f, current_frequency);
+        Superluminal::Slider("Amplitude", 0.1f, 2.0f, current_amplitude);
+        Superluminal::Slider("Noise Level", 0.0f, 0.5f, current_noise_level);
+
+        frequency.store(current_frequency, std::memory_order_relaxed);
+        amplitude.store(current_amplitude, std::memory_order_relaxed);
+        noise_level.store(current_noise_level, std::memory_order_relaxed);
     }));
 
     // Both cells resize to fit below the control bar.
@@ -62,7 +71,10 @@ static Result App() {
 
     JST_CHECK(Superluminal::RealtimeLoop([&](const bool& running){
         while (running) {
-            GenerateTestSignal(data, frequency, amplitude, noise_level);
+            GenerateTestSignal(data,
+                               frequency.load(std::memory_order_relaxed),
+                               amplitude.load(std::memory_order_relaxed),
+                               noise_level.load(std::memory_order_relaxed));
 
             Superluminal::Update();
             std::this_thread::sleep_for(std::chrono::milliseconds(10));

--- a/examples/superluminal/global_interface/meson.build
+++ b/examples/superluminal/global_interface/meson.build
@@ -1,0 +1,19 @@
+deps = [
+    'JETSTREAM_SUPERLUMINAL_AVAILABLE',
+]
+
+all_deps_found = true
+foreach x_dep : deps
+    all_deps_found = all_deps_found and cfg_lst.get(x_dep, false)
+endforeach
+
+if all_deps_found
+    executable(
+        'global_interface',
+        'global_interface.cc',
+        dependencies: libjetstream_dep,
+        install: false,
+    )
+endif
+
+sum_lst += {'Superluminal | Global Interface': all_deps_found}

--- a/examples/superluminal/meson.build
+++ b/examples/superluminal/meson.build
@@ -1,5 +1,6 @@
 subdir('hello_world')
 subdir('realtime')
 subdir('interface')
+subdir('global_interface')
 subdir('remote')
 subdir('constellation')

--- a/include/jetstream/superluminal.hh
+++ b/include/jetstream/superluminal.hh
@@ -152,6 +152,10 @@ class Superluminal {
         return GetInstance()->interface(name, mosaic, callback);
     }
 
+    static Result GlobalInterface(const std::function<void()>& callback) {
+        return GetInstance()->globalInterface(callback);
+    }
+
     static Result Box(const std::string& title, const Mosaic& mosaic, const std::function<void()>& callback) {
         return GetInstance()->box(title, mosaic, callback);
     }
@@ -204,6 +208,7 @@ class Superluminal {
 
     Result plot(const std::string& name, const Mosaic& mosaic, const PlotConfig& config);
     Result interface(const std::string& name, const Mosaic& mosaic, const std::function<void()>& callback);
+    Result globalInterface(const std::function<void()>& callback);
     Result box(const std::string& title, const Mosaic& mosaic, const std::function<void()>& callback);
     Result text(const std::string& content);
     Result slider(const std::string& label, F32 min, F32 max, F32& value);

--- a/src/superluminal/base.cc
+++ b/src/superluminal/base.cc
@@ -134,6 +134,8 @@ struct Superluminal::Impl {
     };
 
     std::unordered_map<std::string, PlotState> plots;
+    std::function<void()> globalCallback;
+    F32 globalCallbackHeight = 0.0f;
 
     Result createGraph();
     Result destroyGraph();
@@ -372,6 +374,23 @@ Result Superluminal::start() {
                     return Result::SUCCESS;
                 }
 
+                if (impl->globalCallback) {
+                    const ImGuiViewport* viewport = ImGui::GetMainViewport();
+
+                    ImGui::SetNextWindowPos(viewport->WorkPos);
+                    ImGui::SetNextWindowSize({viewport->WorkSize.x, 0.0f});
+
+                    ImGui::Begin("Global Interface", nullptr, ImGuiWindowFlags_NoSavedSettings |
+                                                              ImGuiWindowFlags_NoMove |
+                                                              ImGuiWindowFlags_NoDecoration);
+
+                    impl->globalCallback();
+
+                    impl->globalCallbackHeight = ImGui::GetWindowSize().y;
+
+                    ImGui::End();
+                }
+
                 for (auto& [_, plot] : impl->plots) {
                     static ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration |
                                                     ImGuiWindowFlags_NoMove |
@@ -381,14 +400,16 @@ Result Superluminal::start() {
 
                     const ImGuiViewport* viewport = ImGui::GetMainViewport();
 
+                    const F32 controlsOffset = impl->globalCallbackHeight;
+
                     ImVec2 workSize = {
                         (viewport->WorkSize.x / impl->mosaicDims.x) * plot.mosaicSize.x,
-                        (viewport->WorkSize.y / impl->mosaicDims.y) * plot.mosaicSize.y
+                        ((viewport->WorkSize.y - controlsOffset) / impl->mosaicDims.y) * plot.mosaicSize.y
                     };
 
                     ImVec2 workPos = {
                         viewport->WorkPos.x + ((viewport->WorkSize.x / impl->mosaicDims.x) * plot.mosaicOffset.x),
-                        viewport->WorkPos.y + ((viewport->WorkSize.y / impl->mosaicDims.y) * plot.mosaicOffset.y)
+                        viewport->WorkPos.y + controlsOffset + (((viewport->WorkSize.y - controlsOffset) / impl->mosaicDims.y) * plot.mosaicOffset.y)
                     };
 
                     ImGui::SetNextWindowPos(workPos);
@@ -783,6 +804,26 @@ Result Superluminal::interface(const std::string& name, const Mosaic& mosaic, co
     JST_CHECK(impl->calculateMosaicParams(mosaic, state));
 
     JST_INFO("[SUPERLUMINAL] Created interface '{}'.", state.name);
+    return Result::SUCCESS;
+}
+
+Result Superluminal::globalInterface(const std::function<void()>& callback) {
+    JST_DEBUG("[SUPERLUMINAL] Registering global interface.");
+
+    // Check boundaries.
+
+    if (!impl->initialized) {
+        JST_CHECK(initialize());
+    }
+
+    if (impl->running) {
+        JST_FATAL("[SUPERLUMINAL] Can't register global interface because the instance is already commited.");
+        return Result::ERROR;
+    }
+
+    impl->globalCallback = callback;
+
+    JST_INFO("[SUPERLUMINAL] Created global interface.");
     return Result::SUCCESS;
 }
 


### PR DESCRIPTION
Superluminal can render plots into mosaic cells, but there's no way to draw a control panel that isn't itself a cell. GlobalInterface registers a callback drawn once per frame above the mosaic so it allows for non-cell components. (like gr-cyberether slider or future overlays) 

 - Superluminal::GlobalInterface(callback)  callback returns F32 height
 - Plot layout subtracts the reported height from available viewport space
 - Registration follows the same guards as Interface/Plot (lazy init, rejected once running)
  
