### PR TITLE
Add support for multi-sdr receiver devices like KrakenSDR or KerberosSDR

### DIFF
--- a/include/jetstream/domains/io/soapy/block.hh
+++ b/include/jetstream/domains/io/soapy/block.hh
@@ -15,6 +15,7 @@ struct Soapy : public Block::Config {
     F32 sampleRate = 2.0e6;
     bool automaticGain = true;
     bool biasTee = false;
+    U64 webUsbRefresh = 0;
     U64 numberOfBatches = 8;
     U64 numberOfTimeSamples = 8192;
     U64 bufferMultiplier = 4;
@@ -23,7 +24,7 @@ struct Soapy : public Block::Config {
     JST_BLOCK_DOMAIN("IO");
     JST_BLOCK_PARAMS(modulePath, hintString, deviceString,
                      streamString, frequency, frequencyStep,
-                     sampleRate, automaticGain, biasTee, numberOfBatches,
+                     sampleRate, automaticGain, biasTee, webUsbRefresh, numberOfBatches,
                      numberOfTimeSamples, bufferMultiplier);
     JST_BLOCK_DESCRIPTION(
         "Soapy SDR",

--- a/src/compositor/default/views/flowgraph/editor/config/base.hh
+++ b/src/compositor/default/views/flowgraph/editor/config/base.hh
@@ -16,6 +16,7 @@
 #include "uint.hh"
 #include "vector.hh"
 #include "vector_inline.hh"
+#include "webusb_dropdown.hh"
 
 namespace Jetstream {
 
@@ -34,6 +35,8 @@ struct FlowgraphConfigFieldInstance {
 
         if (kind == "dropdown") {
             dropdown.update(std::move(config));
+        } else if (kind == "webusb-dropdown") {
+            webUsbDropdown.update(std::move(config));
         } else if (kind == "float") {
             floatField.update(std::move(config));
         } else if (kind == "int") {
@@ -84,6 +87,8 @@ struct FlowgraphConfigFieldInstance {
     void render(const Sakura::Context& ctx) const {
         if (kind == "dropdown") {
             dropdown.render(ctx);
+        } else if (kind == "webusb-dropdown") {
+            webUsbDropdown.render(ctx);
         } else if (kind == "float") {
             floatField.render(ctx);
         } else if (kind == "int") {
@@ -129,6 +134,7 @@ struct FlowgraphConfigFieldInstance {
 
     std::string kind;
     FlowgraphConfigDropdownField dropdown;
+    FlowgraphConfigWebUsbDropdownField webUsbDropdown;
     FlowgraphConfigFloatField floatField;
     FlowgraphConfigIntField intField;
     FlowgraphConfigUIntField uintField;

--- a/src/compositor/default/views/flowgraph/editor/config/webusb_dropdown.hh
+++ b/src/compositor/default/views/flowgraph/editor/config/webusb_dropdown.hh
@@ -1,0 +1,122 @@
+#ifndef JETSTREAM_COMPOSITOR_IMPL_DEFAULT_VIEWS_FLOWGRAPH_CONFIG_WEBUSB_DROPDOWN_HH
+#define JETSTREAM_COMPOSITOR_IMPL_DEFAULT_VIEWS_FLOWGRAPH_CONFIG_WEBUSB_DROPDOWN_HH
+
+#include "dropdown.hh"
+
+#ifdef JST_OS_BROWSER
+#include <emscripten.h>
+#endif
+
+#include <any>
+#include <limits>
+
+namespace Jetstream {
+
+struct FlowgraphConfigWebUsbDropdownField {
+    using Config = FlowgraphConfigFieldConfig;
+
+    void update(Config config) {
+        this->config = std::move(config);
+
+        auto dropdownConfig = this->config;
+        const auto separator = dropdownConfig.format.find(':');
+        dropdownConfig.format = "dropdown";
+        if (separator != std::string::npos) {
+            dropdownConfig.format += this->config.format.substr(separator);
+        }
+        dropdown.update(std::move(dropdownConfig));
+
+        authorizeButton.update({
+            .id = this->config.id + "AuthorizeUsb",
+            .str = "Authorize SDR Device",
+            .size = {-1.0f, 0.0f},
+            .variant = Sakura::Button::Variant::Action,
+            .onClick = []() {
+#ifdef JST_OS_BROWSER
+                MAIN_THREAD_EM_ASM({
+                    if (!navigator.usb || globalThis.cyberetherWebUsbRequestPending) {
+                        return;
+                    }
+                    globalThis.cyberetherWebUsbRequestPending = true;
+                    navigator.usb.requestDevice({
+                        filters: [
+                            {vendorId: 0x0bda},
+                            {vendorId: 0x1d50},
+                            {classCode: 0xff},
+                        ],
+                    }).then(() => {
+                        globalThis.cyberetherWebUsbGeneration =
+                            (globalThis.cyberetherWebUsbGeneration || 0) + 1;
+                    }).catch(error => {
+                        if (error.name !== "NotFoundError") {
+                            console.error("WebUSB authorization failed:", error);
+                        }
+                    }).finally(() => {
+                        globalThis.cyberetherWebUsbRequestPending = false;
+                    });
+                });
+#endif
+            },
+        });
+
+#ifdef JST_OS_BROWSER
+        if (!generationInitialized) {
+            observedGeneration = CurrentGeneration();
+            generationInitialized = true;
+        }
+#endif
+    }
+
+    void render(const Sakura::Context& ctx) const {
+        dropdown.render(ctx);
+        authorizeButton.render(ctx);
+
+#ifdef JST_OS_BROWSER
+        const U64 generation = CurrentGeneration();
+        if (generation == observedGeneration) {
+            return;
+        }
+        observedGeneration = generation;
+
+        U64 refresh = 0;
+        if (config.values.contains("webUsbRefresh")) {
+            try {
+                refresh = std::any_cast<U64>(config.values.at("webUsbRefresh"));
+            } catch (const std::bad_any_cast&) {
+            }
+        }
+        if (refresh == std::numeric_limits<U64>::max()) {
+            refresh = 0;
+        } else {
+            ++refresh;
+        }
+
+        Parser::Map patch;
+        patch["webUsbRefresh"] = refresh;
+        if (config.onApply) {
+            config.onApply(std::move(patch), false);
+        }
+#endif
+    }
+
+ private:
+#ifdef JST_OS_BROWSER
+    static U64 CurrentGeneration() {
+        return static_cast<U64>(MAIN_THREAD_EM_ASM_INT({
+            return globalThis.cyberetherWebUsbGeneration || 0;
+        }));
+    }
+#endif
+
+    Config config;
+    FlowgraphConfigDropdownField dropdown;
+    mutable Sakura::Button authorizeButton;
+#ifdef JST_OS_BROWSER
+    mutable U64 observedGeneration = 0;
+    bool generationInitialized = false;
+#endif
+};
+
+}  // namespace Jetstream
+
+#endif  // JETSTREAM_COMPOSITOR_IMPL_DEFAULT_VIEWS_FLOWGRAPH_CONFIG_WEBUSB_DROPDOWN_HH

--- a/src/domains/io/soapy/block_impl.cc
+++ b/src/domains/io/soapy/block_impl.cc
@@ -87,7 +87,12 @@ Result SoapyImpl::define() {
          Modules::SoapyImpl::ListAvailableDevices(config.hintString)) {
         deviceOptions.push_back(jst::fmt::format("{}({})", label, label));
     }
+#ifdef JST_OS_BROWSER
+    deviceDropdown = jst::fmt::format("webusb-dropdown:{}",
+                                      jst::fmt::join(deviceOptions, ","));
+#else
     deviceDropdown = jst::fmt::format("dropdown:{}", jst::fmt::join(deviceOptions, ","));
+#endif
 
     JST_CHECK(defineInterfaceConfig("deviceString",
                                     "Device",

--- a/src/domains/io/soapy/block_tests.cc
+++ b/src/domains/io/soapy/block_tests.cc
@@ -14,12 +14,14 @@ TEST_CASE("Soapy block Bias-T defaults off", "[modules][io][soapy][block][bias-t
     REQUIRE_FALSE(config.biasTee);
 
     config.biasTee = true;
+    config.webUsbRefresh = 3;
     Parser::Map serialized;
     REQUIRE(config.serialize(serialized) == Result::SUCCESS);
 
     Blocks::Soapy restored;
     REQUIRE(restored.deserialize(serialized) == Result::SUCCESS);
     REQUIRE(restored.biasTee);
+    REQUIRE(restored.webUsbRefresh == 3);
 }
 
 TEST_CASE_METHOD(FlowgraphFixture,

--- a/subprojects/librtlsdr.wrap
+++ b/subprojects/librtlsdr.wrap
@@ -4,6 +4,7 @@ source_url = https://github.com/steve-m/librtlsdr/archive/1261fbb285297da08f4620
 source_filename = librtlsdr-1261fbb285297da08f4620b18871b6d6d9ec2a7b.zip
 source_hash = 79925da4e274b87a98e5364459e0e3faf346bd56dfcb7d38fa089e5cc6785797
 patch_directory = librtlsdr
+diff_files = librtlsdr/emscripten-shared-context.diff
 wrapdb_version = 0.7.0
 
 [provide]

--- a/subprojects/libusb-browser.wrap
+++ b/subprojects/libusb-browser.wrap
@@ -3,7 +3,7 @@ directory = libusb-browser-git
 url = https://github.com/libusb/libusb.git
 revision = 2101df11b92272eebf0355818f84c12fd040e2ff
 patch_directory = libusb-browser
-diff_files = libusb-browser/wasmfs-fcntl-fix.diff, libusb-browser/webusb-transfer-cancellation.diff
+diff_files = libusb-browser/wasmfs-fcntl-fix.diff, libusb-browser/webusb-transfer-cancellation.diff, libusb-browser/webusb-open-timeout.diff, libusb-browser/webusb-rtl2832-descriptors.diff, libusb-browser/webusb-transfer-serialization.diff
 
 [provide]
 libusb-browser = libusb_dep

--- a/subprojects/packagefiles/librtlsdr/emscripten-shared-context.diff
+++ b/subprojects/packagefiles/librtlsdr/emscripten-shared-context.diff
@@ -1,0 +1,40 @@
+diff --git a/src/librtlsdr.c b/src/librtlsdr.c
+index 7c59a99..0000000 100644
+--- a/src/librtlsdr.c
++++ b/src/librtlsdr.c
+@@ -27,5 +27,35 @@
+ 
+ #include <libusb.h>
+ 
++#ifdef __EMSCRIPTEN__
++#include <pthread.h>
++
++static libusb_context *rtlsdr_browser_libusb_context;
++static int rtlsdr_browser_libusb_result;
++static pthread_once_t rtlsdr_browser_libusb_once = PTHREAD_ONCE_INIT;
++
++static void rtlsdr_browser_libusb_initialize(void)
++{
++	rtlsdr_browser_libusb_result =
++		libusb_init(&rtlsdr_browser_libusb_context);
++}
++
++static int rtlsdr_browser_libusb_init(libusb_context **ctx)
++{
++	pthread_once(&rtlsdr_browser_libusb_once,
++		     rtlsdr_browser_libusb_initialize);
++	*ctx = rtlsdr_browser_libusb_context;
++	return rtlsdr_browser_libusb_result;
++}
++
++static void rtlsdr_browser_libusb_exit(libusb_context *ctx)
++{
++	(void)ctx;
++}
++
++#define libusb_init rtlsdr_browser_libusb_init
++#define libusb_exit rtlsdr_browser_libusb_exit
++#endif
++
+ /*
+  * All libusb callback functions should be marked with the LIBUSB_CALL macro

--- a/subprojects/packagefiles/libusb-browser/webusb-open-timeout.diff
+++ b/subprojects/packagefiles/libusb-browser/webusb-open-timeout.diff
@@ -1,0 +1,48 @@
+diff --git a/libusb/os/emscripten_webusb.cpp b/libusb/os/emscripten_webusb.cpp
+index a0090890..00000000 100644
+--- a/libusb/os/emscripten_webusb.cpp
++++ b/libusb/os/emscripten_webusb.cpp
+@@ -140,18 +140,36 @@ EM_JS(void, usbi_em_copy_from_dataview, (void* dst, EM_VAL src), {
+ EM_JS(EM_VAL, usbi_em_device_safe_open_close, (EM_VAL device, bool open), {
+ 	device = Emval.toValue(device);
+ 	const symbol = Symbol.for('libusb.open_close_chain');
++	const withTimeout = (promise, operation) => {
++		let timer;
++		const timeout = new Promise((_, reject) => {
++			timer = setTimeout(() => {
++				reject(new DOMException(
++					'WebUSB ' + operation + ' timed out after 10 seconds',
++					'TimeoutError'));
++			}, 10000);
++		});
++		return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
++	};
+ 	let promiseChain = device[symbol] ?? Promise.resolve(0);
+-	device[symbol] = promiseChain = promiseChain.then(async refCount => {
++	device[symbol] = promiseChain = promiseChain.catch(error => {
++		console.warn('Recovering failed WebUSB open/close chain:', error);
++		return device.opened ? 1 : 0;
++	}).then(async refCount => {
+ 		if (open) {
+-			if (!refCount++) {
+-				await device.open();
++			if (!refCount && !device.opened) {
++				await withTimeout(device.open(), 'open');
+ 			}
+-		} else {
+-			if (!--refCount) {
+-				await device.close();
++			return refCount + 1;
++		}
++
++		if (refCount <= 1) {
++			if (device.opened) {
++				await withTimeout(device.close(), 'close');
+ 			}
++			return 0;
+ 		}
+-		return refCount;
++		return refCount - 1;
+ 	});
+ 	return Emval.toHandle(promiseChain);
+ });

--- a/subprojects/packagefiles/libusb-browser/webusb-rtl2832-descriptors.diff
+++ b/subprojects/packagefiles/libusb-browser/webusb-rtl2832-descriptors.diff
@@ -1,0 +1,173 @@
+diff --git a/libusb/os/emscripten_webusb.cpp b/libusb/os/emscripten_webusb.cpp
+index 159eb0c1..0082fbd7 100644
+--- a/libusb/os/emscripten_webusb.cpp
++++ b/libusb/os/emscripten_webusb.cpp
+@@ -445,6 +445,10 @@ struct CachedDevice {
+ 	static val initFromDevice(val&& web_usb_dev, libusb_device* libusb_dev) {
+ 		auto cachedDevicePtr = WebUsbDevicePtr(libusb_dev);
+ 		cachedDevicePtr.emplace(std::move(web_usb_dev));
++		if (cachedDevicePtr->device["vendorId"].as<uint16_t>() == 0x0bda &&
++			cachedDevicePtr->device["productId"].as<uint16_t>() == 0x2832) {
++			co_return cachedDevicePtr->initRtl2832FromProperties(libusb_dev);
++		}
+ 		bool must_close = false;
+ 		val result = co_await cachedDevicePtr->initFromDeviceWithoutClosing(
+ 			libusb_dev, must_close);
+@@ -520,6 +524,157 @@ private:
+ 	val device;
+ 	std::vector<std::unique_ptr<usbi_configuration_descriptor>> configurations;
+ 
++	int initRtl2832FromProperties(libusb_device* dev) {
++		auto version = [](uint8_t major, uint8_t minor, uint8_t subminor) {
++			return (uint16_t)((major << 8) | (minor << 4) | subminor);
++		};
++
++		auto& desc = dev->device_descriptor;
++		desc = {
++			.bLength = LIBUSB_DT_DEVICE_SIZE,
++			.bDescriptorType = LIBUSB_DT_DEVICE,
++			.bcdUSB = version(device["usbVersionMajor"].as<uint8_t>(),
++							  device["usbVersionMinor"].as<uint8_t>(),
++							  device["usbVersionSubminor"].as<uint8_t>()),
++			.bDeviceClass = device["deviceClass"].as<uint8_t>(),
++			.bDeviceSubClass = device["deviceSubclass"].as<uint8_t>(),
++			.bDeviceProtocol = device["deviceProtocol"].as<uint8_t>(),
++			.bMaxPacketSize0 = 64,
++			.idVendor = device["vendorId"].as<uint16_t>(),
++			.idProduct = device["productId"].as<uint16_t>(),
++			.bcdDevice = version(device["deviceVersionMajor"].as<uint8_t>(),
++								device["deviceVersionMinor"].as<uint8_t>(),
++								device["deviceVersionSubminor"].as<uint8_t>()),
++			.iManufacturer = 0,
++			.iProduct = 0,
++			.iSerialNumber = 0,
++			.bNumConfigurations =
++				device["configurations"]["length"].as<uint8_t>(),
++		};
++		dev->speed = desc.bcdUSB >= 0x0200
++			? LIBUSB_SPEED_HIGH
++			: LIBUSB_SPEED_FULL;
++
++		if (auto error = usbi_sanitize_device(dev)) {
++			return error;
++		}
++
++		struct EndpointDescriptor {
++			uint8_t bLength;
++			uint8_t bDescriptorType;
++			uint8_t bEndpointAddress;
++			uint8_t bmAttributes;
++			uint16_t wMaxPacketSize;
++			uint8_t bInterval;
++		} LIBUSB_PACKED;
++
++		auto webConfigurations = device["configurations"];
++		const auto configurationCount =
++			webConfigurations["length"].as<size_t>();
++		configurations.reserve(configurationCount);
++		for (size_t configIndex = 0;
++			 configIndex < configurationCount;
++			 ++configIndex) {
++			auto webConfiguration = webConfigurations[configIndex];
++			auto webInterfaces = webConfiguration["interfaces"];
++			const auto interfaceCount = webInterfaces["length"].as<size_t>();
++			size_t totalLength = LIBUSB_DT_CONFIG_SIZE;
++			for (size_t interfaceIndex = 0;
++				 interfaceIndex < interfaceCount;
++				 ++interfaceIndex) {
++				auto alternates = webInterfaces[interfaceIndex]["alternates"];
++				const auto alternateCount = alternates["length"].as<size_t>();
++				for (size_t alternateIndex = 0;
++					 alternateIndex < alternateCount;
++					 ++alternateIndex) {
++					auto endpoints = alternates[alternateIndex]["endpoints"];
++					totalLength += LIBUSB_DT_INTERFACE_SIZE +
++						endpoints["length"].as<size_t>() *
++							LIBUSB_DT_ENDPOINT_SIZE;
++				}
++			}
++
++			auto& config = configurations.emplace_back(
++				(usbi_configuration_descriptor*)::operator new(totalLength));
++			memset(config.get(), 0, totalLength);
++			config->bLength = LIBUSB_DT_CONFIG_SIZE;
++			config->bDescriptorType = LIBUSB_DT_CONFIG;
++			config->wTotalLength =
++				libusb_cpu_to_le16((uint16_t)totalLength);
++			config->bNumInterfaces = (uint8_t)interfaceCount;
++			config->bConfigurationValue =
++				webConfiguration["configurationValue"].as<uint8_t>();
++			config->bmAttributes = 0x80;
++
++			auto* cursor = (uint8_t*)config.get() + LIBUSB_DT_CONFIG_SIZE;
++			for (size_t interfaceIndex = 0;
++				 interfaceIndex < interfaceCount;
++				 ++interfaceIndex) {
++				auto webInterface = webInterfaces[interfaceIndex];
++				auto alternates = webInterface["alternates"];
++				const auto alternateCount = alternates["length"].as<size_t>();
++				for (size_t alternateIndex = 0;
++					 alternateIndex < alternateCount;
++					 ++alternateIndex) {
++					auto alternate = alternates[alternateIndex];
++					auto endpoints = alternate["endpoints"];
++					const auto endpointCount =
++						endpoints["length"].as<size_t>();
++					auto* interfaceDesc =
++						(usbi_interface_descriptor*)cursor;
++					*interfaceDesc = {
++						.bLength = LIBUSB_DT_INTERFACE_SIZE,
++						.bDescriptorType = LIBUSB_DT_INTERFACE,
++						.bInterfaceNumber =
++							webInterface["interfaceNumber"].as<uint8_t>(),
++						.bAlternateSetting =
++							alternate["alternateSetting"].as<uint8_t>(),
++						.bNumEndpoints = (uint8_t)endpointCount,
++						.bInterfaceClass =
++							alternate["interfaceClass"].as<uint8_t>(),
++						.bInterfaceSubClass =
++							alternate["interfaceSubclass"].as<uint8_t>(),
++						.bInterfaceProtocol =
++							alternate["interfaceProtocol"].as<uint8_t>(),
++						.iInterface = 0,
++					};
++					cursor += LIBUSB_DT_INTERFACE_SIZE;
++
++					for (size_t endpointIndex = 0;
++						 endpointIndex < endpointCount;
++						 ++endpointIndex) {
++						auto endpoint = endpoints[endpointIndex];
++						const auto type =
++							endpoint["type"].as<std::string>();
++						uint8_t attributes = LIBUSB_TRANSFER_TYPE_BULK;
++						if (type == "interrupt") {
++							attributes = LIBUSB_TRANSFER_TYPE_INTERRUPT;
++						} else if (type == "isochronous") {
++							attributes = LIBUSB_TRANSFER_TYPE_ISOCHRONOUS;
++						}
++						auto* endpointDesc = (EndpointDescriptor*)cursor;
++						*endpointDesc = {
++							.bLength = LIBUSB_DT_ENDPOINT_SIZE,
++							.bDescriptorType = LIBUSB_DT_ENDPOINT,
++							.bEndpointAddress = (uint8_t)(
++								endpoint["endpointNumber"].as<uint8_t>() |
++								(endpoint["direction"].as<std::string>() == "in"
++									 ? LIBUSB_ENDPOINT_IN
++									 : LIBUSB_ENDPOINT_OUT)),
++							.bmAttributes = attributes,
++							.wMaxPacketSize = libusb_cpu_to_le16(
++								endpoint["packetSize"].as<uint16_t>()),
++							.bInterval = 0,
++						};
++						cursor += LIBUSB_DT_ENDPOINT_SIZE;
++					}
++				}
++			}
++		}
++
++		return LIBUSB_SUCCESS;
++	}
++
+ 	CaughtPromise requestDescriptor(libusb_descriptor_type desc_type,
+ 									uint8_t desc_index,
+ 									uint16_t max_length) const {

--- a/subprojects/packagefiles/libusb-browser/webusb-transfer-serialization.diff
+++ b/subprojects/packagefiles/libusb-browser/webusb-transfer-serialization.diff
@@ -1,0 +1,104 @@
+diff --git a/libusb/os/emscripten_webusb.cpp b/libusb/os/emscripten_webusb.cpp
+index 0082fbd7..b97d822a 100644
+--- a/libusb/os/emscripten_webusb.cpp
++++ b/libusb/os/emscripten_webusb.cpp
+@@ -118,6 +118,48 @@ EM_JS(void, usbi_em_copy_from_dataview, (void* dst, EM_VAL src), {
+ 	HEAPU8.set(src, dst);
+ });
+ 
++EM_JS(EM_VAL, usbi_em_control_transfer,
++	  (EM_VAL device_handle, uint8_t request_type, uint8_t request,
++	   uint16_t value, uint16_t index, uint16_t length, const uint8_t* data), {
++	const device = Emval.toValue(device_handle);
++	const params = {
++		requestType:
++			['standard', 'class', 'vendor'][(request_type >> 5) & 0x03] ??
++			'unknown',
++		recipient: ['device', 'interface', 'endpoint'][request_type & 0x0f] ?? 'other',
++		request,
++		value,
++		index,
++	};
++	const input = (request_type & 0x80) !== 0;
++	const payload = input ? undefined : HEAPU8.slice(data, data + length);
++	const isRtl2832 = device.vendorId === 0x0bda && device.productId === 0x2832;
++	const run = async () => {
++		const transfer = () => input
++			? device.controlTransferIn(params, length)
++			: device.controlTransferOut(params, payload);
++		if (isRtl2832) {
++			await new Promise(resolve => setTimeout(resolve, 1));
++		}
++		try {
++			return await transfer();
++		} catch (error) {
++			if (!isRtl2832 || !(error instanceof DOMException) ||
++				error.name !== 'NetworkError') {
++				throw error;
++			}
++			await new Promise(resolve => setTimeout(resolve, 1));
++			return transfer();
++		}
++	};
++
++	const symbol = Symbol.for('libusb.control_transfer_chain');
++	const previous = device[symbol] ?? Promise.resolve();
++	const operation = previous.catch(() => undefined).then(run);
++	device[symbol] = operation.catch(() => undefined);
++	return Emval.toHandle(operation);
++});
++
+ // Our implementation proxies operations from multiple threads to the same
+ // underlying USBDevice on the main thread. This can lead to issues when
+ // multiple threads try to open/close the same device at the same time.
+@@ -337,47 +379,9 @@ static std::invoke_result_t<Func>::AwaitResult awaitOnMain(Func&& func) {
+ // A helper that makes a control transfer given a setup pointer (assumed to be
+ // followed by data payload for out-transfers).
+ val makeControlTransferPromise(const val& dev, libusb_control_setup* setup) {
+-	auto params = val::object();
+-
+-	const char* request_type = "unknown";
+-	// See LIBUSB_REQ_TYPE in windows_winusb.h (or docs for `bmRequestType`).
+-	switch (setup->bmRequestType & (0x03 << 5)) {
+-		case LIBUSB_REQUEST_TYPE_STANDARD:
+-			request_type = "standard";
+-			break;
+-		case LIBUSB_REQUEST_TYPE_CLASS:
+-			request_type = "class";
+-			break;
+-		case LIBUSB_REQUEST_TYPE_VENDOR:
+-			request_type = "vendor";
+-			break;
+-	}
+-	params.set("requestType", request_type);
+-
+-	const char* recipient = "other";
+-	switch (setup->bmRequestType & 0x0f) {
+-		case LIBUSB_RECIPIENT_DEVICE:
+-			recipient = "device";
+-			break;
+-		case LIBUSB_RECIPIENT_INTERFACE:
+-			recipient = "interface";
+-			break;
+-		case LIBUSB_RECIPIENT_ENDPOINT:
+-			recipient = "endpoint";
+-			break;
+-	}
+-	params.set("recipient", recipient);
+-
+-	params.set("request", setup->bRequest);
+-	params.set("value", setup->wValue);
+-	params.set("index", setup->wIndex);
+-
+-	if (setup->bmRequestType & LIBUSB_ENDPOINT_IN) {
+-		return dev.call<val>("controlTransferIn", params, setup->wLength);
+-	} else {
+-		return dev.call<val>("controlTransferOut", params,
+-							 getUnsharedMemoryView(setup + 1, setup->wLength));
+-	}
++	return val::take_ownership(usbi_em_control_transfer(
++		dev.as_handle(), setup->bmRequestType, setup->bRequest, setup->wValue,
++		setup->wIndex, setup->wLength, (const uint8_t*)(setup + 1)));
+ }
+ 
+ // Smart pointer for managing pointers to places allocated by libusb inside its

--- a/subprojects/soapyrtlsdr.wrap
+++ b/subprojects/soapyrtlsdr.wrap
@@ -1,10 +1,9 @@
-[wrap-file]
-directory = SoapyRTLSDR-soapy-rtl-sdr-0.3.3
-source_url = https://github.com/pothosware/SoapyRTLSDR/archive/refs/tags/soapy-rtl-sdr-0.3.3.tar.gz
-source_filename = SoapyRTLSDR-soapy-rtl-sdr-0.3.3.tar.gz
-source_hash = 757c3c3bd17c5a12c7168db2f2f0fd274457e65f35e23c5ec9aec34e3ef54ece
+[wrap-git]
+directory = SoapyRTLSDR
+url = https://github.com/ooeygui/SoapyRTLSDR.git
+revision = feature/by_index
+depth = 1
 patch_directory = soapyrtlsdr
-wrapdb_version = 0.3.3
 
 [provide]
 soapyrtlsdr = soapyrtlsdr_dep


### PR DESCRIPTION
## Summary
 
 Add support for selecting individual RTL-SDR receivers by USB enumeration index, including multi-receiver devices such as the KerberosSDR and KrakenSDR.
 
 This also adds the browser-side WebUSB authorization and reliability handling needed to use these receivers from the CyberEther WebAssembly application. The same index-based selection works in the native desktop application.
 
 ## Motivation
 
 Multi-receiver SDRs contain several RTL2832U devices that may expose duplicate, empty, or otherwise unreliable serial descriptors. CyberEther previously depended on SoapyRTLSDR's serial-based identity, which could cause multiple entries to resolve to the same physical receiver or prevent serial-less receivers from being selected at all.
 
 The browser application had additional constraints:
 
 - WebUSB access must be initiated by a user gesture.
 - Authorized devices were not automatically reflected in the Soapy device list.
 - Discovery could open every receiver to collect metadata, allowing one active or unresponsive receiver to block the others.
 - Repeated libusb contexts and overlapping browser promises could leave device operations stalled.
 - Reading RTL2832U descriptors through raw control transfers was unreliable in Chromium.
 
 ## Changes
 
 ### Multi-receiver selection
 
 - Use the SoapyRTLSDR `index` argument to identify and open individual receivers.
 - Track a WebUSB refresh generation in the Soapy block configuration.
 - Re-enumerate devices after browser authorization.
 - Pull the index-enabled SoapyRTLSDR implementation from the `feature/by_index` branch pending its upstream PR.
 
 The enumeration index identifies a receiver within the current librtlsdr device list. It is not intended to remain a persistent physical identifier after reconnecting devices or rebooting the system.
 
 ### WebUSB authorization
 
 - Add an **Authorize SDR Device** control to the browser Soapy configuration UI.
 - Dispatch `navigator.usb.requestDevice()` on the browser main thread.
 - Filter the chooser for common SDR vendor/class identifiers.
 - Refresh the available Soapy devices after authorization completes.
 - Ignore chooser cancellation while reporting other authorization failures to the browser console.
 
 ### Browser USB reliability
 
 - Share one process-wide libusb context in librtlsdr under Emscripten.
 - Add bounded WebUSB open and close operations with recoverable promise chains.
 - Construct RTL2832U libusb descriptors from WebUSB metadata instead of issuing unreliable raw descriptor control transfers.
 - Serialize control transfers per device so C-side timeouts do not allow underlying browser promises to overlap.
 - Add short pacing and one retry for transient RTL2832U `NetworkError` failures.
 
 These workarounds are scoped to the Emscripten/WebUSB paths and do not alter native libusb behavior.
 
 ## Why this is a draft
 
 This PR depends on index-based device selection that is not yet available in an upstream SoapyRTLSDR release. The required changes are currently maintained on: https://github.com/ooeygui/SoapyRTLSDR/tree/feature/by_index

A separate upstream SoapyRTLSDR PR will add cross-platform discovery and opening by USB enumeration index while preserving serial-based selection for compatibility.

CyberEther temporarily tracks that development branch so the complete desktop and WebAssembly integration can be reviewed and tested together. This PR should remain a draft until the SoapyRTLSDR change is accepted and CyberEther can reference an upstream commit or release instead of a contributor fork.

Depends on: https://github.com/pothosware/SoapyRTLSDR/pull/83

Testing

Tested on Windows with RTL2832U/R820T receivers in a KerberosSDR:

 - Built the native CyberEther application.
 - Built the Emscripten/WebGPU application with the WebUSB patches.
 - Ran the native Soapy block/module tests, including serialization of the WebUSB refresh state.
 - Confirmed browser authorization refreshes the SDR device list.
 - Confirmed two enabled receivers enumerate independently as  index=0  and  index=1 .
 - Probed both indexes successfully through  SoapySDRUtil .
 - Configured both receivers at an exact rate of approximately 2 MSps.
 - Measured approximately 2 MSps from each receiver during active native RX tests.
 - Confirmed the browser path completes sample-rate setup and reaches stream-format initialization.

Known limitations

 - WebUSB permissions are specific to the browser profile and origin.
 - Abruptly reloading or closing the page can terminate the Emscripten worker before librtlsdr releases the receiver cleanly.
 - Chromium cannot reset these RTL2832U devices through  `USBDevice.reset()`  on Windows. A receiver left in a faulted state may require disconnecting it or resetting/conditioning it through native libusb before another browser session.
 - Repeated abrupt browser reload stress remains less reliable than orderly graph/device shutdown.
 - I do not have a KrakenSDR, so unable to validate assumptions about indexes and serial numbers, but this change *should* be resilient.
